### PR TITLE
Remove java.util.Date from model entities

### DIFF
--- a/src/main/java/com/jos/dem/vetlog/model/Breed.java
+++ b/src/main/java/com/jos/dem/vetlog/model/Breed.java
@@ -26,7 +26,8 @@ import javax.persistence.Entity;
 import javax.persistence.Enumerated;
 import javax.persistence.GeneratedValue;
 import javax.persistence.Id;
-import java.util.Date;
+
+import java.time.LocalDateTime;
 
 import static javax.persistence.EnumType.STRING;
 import static javax.persistence.GenerationType.AUTO;
@@ -46,6 +47,6 @@ public class Breed {
     @Enumerated(STRING)
     private PetType type;
     @Column(nullable = false)
-    private Date dateCreated = new Date();
+    private LocalDateTime dateCreated = LocalDateTime.now();
 
 }

--- a/src/main/java/com/jos/dem/vetlog/model/Pet.java
+++ b/src/main/java/com/jos/dem/vetlog/model/Pet.java
@@ -31,8 +31,8 @@ import javax.persistence.Id;
 import javax.persistence.JoinColumn;
 import javax.persistence.OneToMany;
 import javax.persistence.OneToOne;
+
 import java.time.LocalDateTime;
-import java.util.Date;
 import java.util.List;
 
 import static javax.persistence.EnumType.STRING;
@@ -67,7 +67,7 @@ public class Pet {
     private Boolean vaccinated = false;
 
     @Column(nullable = false)
-    private Date dateCreated = new Date();
+    private LocalDateTime dateCreated = LocalDateTime.now();
 
     @Column(nullable = false)
     @Enumerated(STRING)

--- a/src/main/java/com/jos/dem/vetlog/model/PetLog.java
+++ b/src/main/java/com/jos/dem/vetlog/model/PetLog.java
@@ -26,7 +26,8 @@ import javax.persistence.GeneratedValue;
 import javax.persistence.Id;
 import javax.persistence.JoinColumn;
 import javax.persistence.ManyToOne;
-import java.util.Date;
+
+import java.time.LocalDateTime;
 
 import static javax.persistence.GenerationType.AUTO;
 
@@ -53,7 +54,7 @@ public class PetLog {
   private String uuid;
 
   @Column(nullable = false)
-  private Date dateCreated = new Date();
+  private LocalDateTime dateCreated = LocalDateTime.now();
 
   @ManyToOne(fetch = FetchType.LAZY)
   @JoinColumn(name = "pet_id")

--- a/src/main/java/com/jos/dem/vetlog/model/RegistrationCode.java
+++ b/src/main/java/com/jos/dem/vetlog/model/RegistrationCode.java
@@ -26,7 +26,6 @@ import javax.persistence.GeneratedValue;
 import javax.persistence.Id;
 import java.time.LocalDate;
 import java.time.LocalDateTime;
-import java.util.Date;
 import java.util.UUID;
 
 import static javax.persistence.GenerationType.AUTO;

--- a/src/main/java/com/jos/dem/vetlog/model/User.java
+++ b/src/main/java/com/jos/dem/vetlog/model/User.java
@@ -27,7 +27,7 @@ import javax.persistence.Enumerated;
 import javax.persistence.GeneratedValue;
 import javax.persistence.Id;
 import java.io.Serializable;
-import java.util.Date;
+import java.time.LocalDateTime;
 
 import static javax.persistence.EnumType.STRING;
 import static javax.persistence.GenerationType.AUTO;
@@ -77,5 +77,5 @@ public class User implements Serializable {
   private Boolean accountNonLocked = true;
 
   @Column(nullable = false)
-  private Date dateCreated = new Date();
+  private LocalDateTime dateCreated = LocalDateTime.now();
 }


### PR DESCRIPTION
Addresses: https://github.com/josdem/vetlog-spring-boot/issues/205

## What's in here:

- Removed java.util.Date from model entities
- Replaced with java.time.LocalDateTime