### PR TITLE
[small]feature/318

### DIFF
--- a/src/main/java/com/josdem/vetlog/binder/UserBinder.java
+++ b/src/main/java/com/josdem/vetlog/binder/UserBinder.java
@@ -34,6 +34,7 @@ public class UserBinder {
         user.setRole(Role.USER);
         user.setFirstName(userCommand.getFirstname());
         user.setLastName(userCommand.getLastname());
+        user.setPhone(userCommand.getPhone());
         user.setEmail(userCommand.getEmail());
         return user;
     }

--- a/src/main/java/com/josdem/vetlog/command/UserCommand.java
+++ b/src/main/java/com/josdem/vetlog/command/UserCommand.java
@@ -38,6 +38,12 @@ public class UserCommand implements Command {
     @Size(min = 1, max = 100)
     private String lastname;
 
+    @Size(min = 1, max = 250)
+    private String phone;
+
+    @Size(min = 1, max = 250)
+    private String countryCode;
+
     @Email
     @Size(min = 1, max = 250)
     private String email;

--- a/src/main/java/com/josdem/vetlog/model/User.java
+++ b/src/main/java/com/josdem/vetlog/model/User.java
@@ -54,6 +54,12 @@ public class User implements Serializable {
     private String lastName;
 
     @Column(nullable = true)
+    private String phone;
+
+    @Column(nullable = true)
+    private String countryCode;
+
+    @Column(nullable = true)
     private String email;
 
     @Column(nullable = true)

--- a/src/main/resources/i18n/messages.properties
+++ b/src/main/resources/i18n/messages.properties
@@ -65,6 +65,7 @@ user.view.create.label=Please, provide your information
 user.view.create.title=Create User
 user.firstname=Name
 user.lastname=Last Name
+user.phone=Phone Number
 user.email=Email
 user.account.created=Your account was created, but you need to activate it. Please check your email
 user.error.password.equals=The passwords are not equals

--- a/src/main/resources/i18n/messages_es.properties
+++ b/src/main/resources/i18n/messages_es.properties
@@ -68,6 +68,7 @@ user.view.create.label=Por favor, provee tu información
 user.view.create.title=Crear Usuario
 user.firstname=Nombre
 user.lastname=Apellidos
+user.phone=N�mero de Tel�fono
 user.email=Correo Electrónico
 user.account.created=Tú cuenta fue creada, pero necesitas activarla, por favor revisa tu cuenta de correo
 user.error.password.equals=Las contraseñas no coinciden

--- a/src/main/resources/templates/user/create.html
+++ b/src/main/resources/templates/user/create.html
@@ -3,6 +3,27 @@
 <head>
     <title th:text="#{user.view.create.title}"></title>
     <head th:insert="~{fragments/include}"/>
+    <style>
+        .phone-container {
+            display: flex;
+            align-items: center;
+        }
+
+        .country-code, .phone-number {
+            flex: 1;
+            height: 34px;
+            box-sizing: border-box;
+        }
+
+        .country-code {
+            width: 20px;
+            margin-right: 10px;
+        }
+
+        .phone-number {
+            flex: 9;
+        }
+    </style>
 </head>
 <body class="login">
 <div th:insert="~{fragments/header}"/>
@@ -42,6 +63,15 @@
                             <input type="text" name='lastname' th:field="*{lastname}" class="form-control"
                                    placeholder="lastname" id='lastname'/>
                             <label th:if="${#fields.hasErrors('lastname')}" th:errors="*{lastname}"></label>
+                            <br/>
+                            <label for="phone"><h4 th:text="#{user.phone}"/></label>
+                            <div class="phone-container">
+                                <input type="text" name="countryCode" value="+52" id="countryCode" class="country-code" />
+                                <input type="text" name="phone" th:field="*{phone}" class="form-control phone-number"
+                                       placeholder="phone number" id="phone"
+                                       pattern="\d{10}" title="Phone number must be 10 digits only" required />
+                            </div>
+                            <label th:if="${#fields.hasErrors('phone')}" th:errors="*{phone}"></label>
                             <br/>
                             <label for="email"><h4 th:text="#{user.email}"/></label>
                             <input type="text" name='email' th:field="*{email}" class="form-control" placeholder="email"


### PR DESCRIPTION
- I can see a Phone field in the user create form
add form
- Format should be + country code and 10 phone number digits
Implemented so that a warning message appears when blurring numbers other than 10 digits.
- Phone field should be located after Lastname field and before Email field
Implemented same as above
- +52 should be pre-populated since it is the country with most of our users.
Create another form and set it to 52 by default. If the user is from another country, this can be changed manually.

Cautionary note
Since the phone number and country code are separated, it is necessary to share their recognition on the backend side.