### PR TITLE
adding Cat vaccination, implementing Strategy pattern

### DIFF
--- a/src/main/java/com/josdem/vetlog/config/VaccinationStrategyConfig.java
+++ b/src/main/java/com/josdem/vetlog/config/VaccinationStrategyConfig.java
@@ -1,0 +1,22 @@
+package com.josdem.vetlog.config;
+
+import com.josdem.vetlog.enums.PetType;
+import com.josdem.vetlog.strategy.vaccination.VaccinationStrategy;
+import com.josdem.vetlog.strategy.vaccination.impl.CatVaccinationStrategy;
+import com.josdem.vetlog.strategy.vaccination.impl.DogVaccinationStrategy;
+import java.util.HashMap;
+import java.util.Map;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+
+@Configuration
+public class VaccinationStrategyConfig {
+    @Bean
+    public Map<PetType, VaccinationStrategy> vaccinationStrategies(
+            DogVaccinationStrategy dogVaccinationStrategy, CatVaccinationStrategy catVaccinationStrategy) {
+        Map<PetType, VaccinationStrategy> strategies = new HashMap<>();
+        strategies.put(PetType.DOG, dogVaccinationStrategy);
+        strategies.put(PetType.CAT, catVaccinationStrategy);
+        return strategies;
+    }
+}

--- a/src/main/java/com/josdem/vetlog/strategy/vaccination/VaccinationStrategy.java
+++ b/src/main/java/com/josdem/vetlog/strategy/vaccination/VaccinationStrategy.java
@@ -1,0 +1,7 @@
+package com.josdem.vetlog.strategy.vaccination;
+
+import com.josdem.vetlog.model.Pet;
+
+public interface VaccinationStrategy {
+    void vaccinate(Pet pet);
+}

--- a/src/main/java/com/josdem/vetlog/strategy/vaccination/impl/CatVaccinationStrategy.java
+++ b/src/main/java/com/josdem/vetlog/strategy/vaccination/impl/CatVaccinationStrategy.java
@@ -1,0 +1,53 @@
+package com.josdem.vetlog.strategy.vaccination.impl;
+
+import com.josdem.vetlog.enums.VaccinationStatus;
+import com.josdem.vetlog.model.Pet;
+import com.josdem.vetlog.model.Vaccination;
+import com.josdem.vetlog.repository.VaccinationRepository;
+import com.josdem.vetlog.strategy.vaccination.VaccinationStrategy;
+import java.time.LocalDate;
+import java.time.LocalDateTime;
+import java.time.temporal.ChronoUnit;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.stereotype.Service;
+
+@Slf4j
+@Service
+@RequiredArgsConstructor
+public class CatVaccinationStrategy implements VaccinationStrategy {
+    private static final String FVRCP = "FVRCP";
+    private static final String DEWORMING = "Deworming";
+    private static final String RABIES = "Rabies";
+
+    private final VaccinationRepository vaccinationRepository;
+
+    @Override
+    public void vaccinate(Pet pet) {
+        Long weeks = ChronoUnit.WEEKS.between(pet.getBirthDate(), LocalDateTime.now());
+
+        switch (weeks.intValue()) {
+            case 0, 1, 2, 3, 4, 5, 6, 7 -> log.info("No vaccination needed");
+            case 8, 9, 10, 11 -> {
+                log.info("First vaccination");
+                registerVaccination(FVRCP, pet);
+                registerVaccination(DEWORMING, pet);
+            }
+            case 12, 13, 14, 15 -> {
+                log.info("Second vaccination");
+                registerVaccination(FVRCP, pet);
+                registerVaccination(DEWORMING, pet);
+            }
+            default -> {
+                log.info("Annual vaccination");
+                registerVaccination(FVRCP, pet);
+                registerVaccination(DEWORMING, pet);
+                registerVaccination(RABIES, pet);
+            }
+        }
+    }
+
+    private void registerVaccination(String name, Pet pet) {
+        vaccinationRepository.save(new Vaccination(null, name, LocalDate.now(), VaccinationStatus.PENDING, pet));
+    }
+}

--- a/src/main/java/com/josdem/vetlog/strategy/vaccination/impl/DogVaccinationStrategy.java
+++ b/src/main/java/com/josdem/vetlog/strategy/vaccination/impl/DogVaccinationStrategy.java
@@ -1,0 +1,65 @@
+package com.josdem.vetlog.strategy.vaccination.impl;
+
+import com.josdem.vetlog.enums.VaccinationStatus;
+import com.josdem.vetlog.model.Pet;
+import com.josdem.vetlog.model.Vaccination;
+import com.josdem.vetlog.repository.VaccinationRepository;
+import com.josdem.vetlog.strategy.vaccination.VaccinationStrategy;
+import java.time.LocalDate;
+import java.time.LocalDateTime;
+import java.time.temporal.ChronoUnit;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.stereotype.Service;
+
+@Slf4j
+@Service
+@RequiredArgsConstructor
+public class DogVaccinationStrategy implements VaccinationStrategy {
+
+    private static final String DA2PP = "DA2PP";
+    private static final String DEWORMING = "Deworming";
+    private static final String LEPTOSPIROSIS = "Leptospirosis";
+    private static final String RABIES = "Rabies";
+
+    private final VaccinationRepository vaccinationRepository;
+
+    @Override
+    public void vaccinate(Pet pet) {
+        Long weeks = ChronoUnit.WEEKS.between(pet.getBirthDate(), LocalDateTime.now());
+
+        switch (weeks.intValue()) {
+            case 0, 1, 2, 3, 4, 5 -> log.info("No vaccination needed");
+            case 6, 7, 8, 9 -> {
+                log.info("First vaccination");
+                registerVaccination(DA2PP, pet);
+                registerVaccination(DEWORMING, pet);
+            }
+            case 10, 11, 12, 13 -> {
+                log.info("Second vaccination");
+                registerVaccination(DA2PP, pet);
+                registerVaccination(DEWORMING, pet);
+                registerVaccination(LEPTOSPIROSIS, pet);
+            }
+            case 14, 15, 16 -> {
+                log.info("Third vaccination");
+                registerVaccination(DA2PP, pet);
+                registerVaccination(DEWORMING, pet);
+                registerVaccination(LEPTOSPIROSIS, pet);
+                registerVaccination(RABIES, pet);
+            }
+            default -> {
+                log.info("Annual vaccination");
+                registerVaccination(DA2PP, pet);
+                registerVaccination(DEWORMING, pet);
+                registerVaccination(LEPTOSPIROSIS, pet);
+                registerVaccination(RABIES, pet);
+                registerVaccination("Canine influenza", pet);
+            }
+        }
+    }
+
+    private void registerVaccination(String name, Pet pet) {
+        vaccinationRepository.save(new Vaccination(null, name, LocalDate.now(), VaccinationStatus.PENDING, pet));
+    }
+}

--- a/src/test/java/com/josdem/vetlog/service/VaccinationServiceTest.java
+++ b/src/test/java/com/josdem/vetlog/service/VaccinationServiceTest.java
@@ -30,8 +30,13 @@ import com.josdem.vetlog.model.Pet;
 import com.josdem.vetlog.model.Vaccination;
 import com.josdem.vetlog.repository.VaccinationRepository;
 import com.josdem.vetlog.service.impl.VaccinationServiceImpl;
+import com.josdem.vetlog.strategy.vaccination.VaccinationStrategy;
+import com.josdem.vetlog.strategy.vaccination.impl.CatVaccinationStrategy;
+import com.josdem.vetlog.strategy.vaccination.impl.DogVaccinationStrategy;
 import java.time.LocalDate;
 import java.time.LocalDateTime;
+import java.util.HashMap;
+import java.util.Map;
 import lombok.extern.slf4j.Slf4j;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
@@ -48,20 +53,34 @@ class VaccinationServiceTest {
     @Mock
     private VaccinationRepository vaccinationRepository;
 
+    private DogVaccinationStrategy dogVaccinationStrategy;
+
+    private CatVaccinationStrategy catVaccinationStrategy;
+
+    private Map<PetType, VaccinationStrategy> vaccinationStrategies;
+
     private final Pet pet = new Pet();
 
     @BeforeEach
     void setup() {
         MockitoAnnotations.openMocks(this);
-        vaccinationService = new VaccinationServiceImpl(vaccinationRepository);
+
+        dogVaccinationStrategy = new DogVaccinationStrategy(vaccinationRepository);
+        catVaccinationStrategy = new CatVaccinationStrategy(vaccinationRepository);
+
+        vaccinationStrategies = new HashMap<>();
+        vaccinationStrategies.put(PetType.DOG, dogVaccinationStrategy);
+        vaccinationStrategies.put(PetType.CAT, catVaccinationStrategy);
+
+        vaccinationService = new VaccinationServiceImpl(vaccinationRepository, vaccinationStrategies);
         pet.setBreed(new Breed());
     }
 
     @Test
-    @DisplayName("not saving a pet if it is not a dog")
-    void shouldNotSavePetIfItIsNotADog(TestInfo testInfo) {
+    @DisplayName("not saving a pet if it is not a dog or cat")
+    void shouldNotSavePetIfItIsNotADogOrCat(TestInfo testInfo) {
         log.info("Test: {}", testInfo.getDisplayName());
-        pet.getBreed().setType(PetType.CAT);
+        pet.getBreed().setType(PetType.BIRD);
         assertThrows(BusinessException.class, () -> vaccinationService.save(pet));
     }
 


### PR DESCRIPTION
# Pull Request Title: Implement Strategy Pattern for Pet Vaccination

## Description
This pull request introduces a strategy pattern implementation for pet vaccination in the `VaccinationService`. Two specific implementations are provided: one for dog vaccinations and one for cat vaccinations.

### Changes Made
- **VaccinationServiceImpl**: Updated the `save` method to utilize a `Map<PetType, VaccinationStrategy>` for delegating vaccination logic based on the pet type.
- **VaccinationStrategyConfig**: Supplies `DogVaccinationStrategy` and `CatVaccinationStrategy` beans, facilitating easier implementation and selection of the appropriate vaccination strategy in the service.
- **VaccinationStrategy Interface**: Created an interface for vaccination strategies that define the `vaccinate` method.
- **DogVaccinationStrategy**: Implemented the vaccination logic specific to dogs.
- **CatVaccinationStrategy**: Implemented the vaccination logic specific to cats.
- **VaccinationServiceTest**: Modified the unit tests to work with the new implementation pattern and ensure all tests pass successfully.

## Notes
Please review the implementation of the strategy pattern for any potential improvements or adjustments. Feedback is welcome!
