### PR TITLE
Implemented test for shouldDeletePet fixing request and #issue:440

### DIFF
--- a/src/test/java/com/josdem/vetlog/controller/PetControllerTest.java
+++ b/src/test/java/com/josdem/vetlog/controller/PetControllerTest.java
@@ -211,4 +211,36 @@ class PetControllerTest {
                 .andExpect(status().isOk())
                 .andExpect(view().name("pet/create"));
     }
+
+
+    @Test
+    @Transactional
+    @DisplayName("deleting a pet successfully")
+    @WithMockUser(username = "josdem", password = "12345678", roles = "USER")
+    void shouldDeletePet(TestInfo testInfo) throws Exception {
+        log.info("Running: {}", testInfo.getDisplayName());
+
+        // Register a pet with OWNED status
+        mockMvc.perform(MockMvcRequestBuilders.multipart("/pet/save")
+                        .file(image)
+                        .with(csrf())
+                        .param("name", "Cremita")
+                        .param("uuid", PET_UUID)
+                        .param("birthDate", "2024-08-22T09:28:00")
+                        .param("dewormed", "true")
+                        .param("vaccinated", "true")
+                        .param("sterilized", "true")
+                        .param("breed", "11")
+                        .param("user", "1")
+                        .param("status", PetStatus.OWNED.toString()) // Set status to OWNED
+                        .param("type", PetType.DOG.toString()))
+                .andExpect(status().isOk())
+                .andExpect(view().name("pet/create"));
+
+        // Perform the delete request
+        mockMvc.perform(get("/pet/delete").param("uuid", PET_UUID))
+                .andExpect(status().isOk())
+                .andExpect(model().attributeExists("message"))
+                .andExpect(view().name("pet/list"));
+    }
 }


### PR DESCRIPTION
This PR updates PetControllerTest.java to implement and test the pet deletion functionality. It adds the shouldDeletePet test case to verify that a pet with the OWNED status can be successfully deleted

  Changes made :-
- Updated PetControllerTest.java:
- Implemented the shouldDeletePet test case to ensure successful deletion of a pet in the OWNED status.
- Enhanced the shouldShowDeletePetForm test to handle the error scenario for pets in IN_ADOPTION status (deletion not allowed).