### PR TITLE
Corrected incorrect label in contact us #490

### DIFF
--- a/src/main/resources/db/migration/V1__vetlog_master.sql
+++ b/src/main/resources/db/migration/V1__vetlog_master.sql
@@ -243,109 +243,11 @@ VALUES
   (66, '2017-06-03 21:23:01', 'Rosy Boa', 'SNAKE'),
   (67, '2017-06-03 21:23:01', 'Gopher', 'SNAKE'),
   (68, '2017-06-03 21:23:01', 'Ball Python', 'SNAKE'),
-  (69, '2017-06-03 21:23:01', 'Tarantula', 'SPIDER');
-
-INSERT INTO
-  `breed`
-VALUES
-  (
-    80,
-    '2025-02-12 11:14:23',
-    'Australian Cattle',
-    'DOG'
-  ),
-  (
-    81,
-    '2025-03-12 11:14:23',
-    'Miniature Pinscher',
-    'DOG'
-  ),
+  (69, '2017-06-03 21:23:01', 'Tarantula', 'SPIDER'),
+  (80,'2025-02-12 11:14:23','Australian Cattle','DOG'),
+  (81,'2025-03-12 11:14:23','Miniature Pinscher','DOG'),
   (82, '2025-02-12 11:14:23', 'Goldendoodle', 'DOG'),
   (83, '2025-02-12 11:14:23', 'Schnoodle', 'DOG'),
-  (
-    84,
-    '2025-12-02 11:19:00',
-    'Alaskan Malamute',
-    'DOG'
-  ),
-  (
-    85,
-    '2025-12-02 11:19:00',
-    'Bernese Mountain Dog',
-    'DOG'
-  ),
-  (86, '2025-12-02 11:19:00', 'Basset Hound', 'DOG'),
-  (87, '2025-12-02 11:19:00', 'Cane Corso', 'DOG'),
-  (88, '2025-12-02 11:19:00', 'Collie', 'DOG'),
-  (89, '2025-12-02 11:19:00', 'Irish Setter', 'DOG'),
-  (
-    90,
-    '2025-12-02 11:19:00',
-    'Italian Greyhound',
-    'DOG'
-  ),
-  (91, '2025-12-02 11:19:00', 'Lhasa Apso', 'DOG'),
-  (
-    92,
-    '2025-12-02 11:19:00',
-    'Norwegian Elkhound',
-    'DOG'
-  ),
-  (93, '2025-12-02 11:19:00', 'Papillon', 'DOG'),
-  (94, '2025-12-02 11:19:00', 'Samoyed', 'DOG'),
-  (95, '2025-12-02 11:19:00', 'Shar Pei', 'DOG'),
-  (
-    96,
-    '2025-12-02 11:19:00',
-    'Springer Spaniel',
-    'DOG'
-  ),
-  (
-    97,
-    '2025-12-02 11:19:00',
-    'Staffordshire Bull Terrier',
-    'DOG'
-  ),
-  (98, '2025-12-02 11:19:00', 'Vizsla', 'DOG'),
-  (99, '2025-12-02 11:19:00', 'Whippet', 'DOG'),
-  (
-    100,
-    '2025-12-02 11:19:00',
-    'West Highland White Terrier',
-    'DOG'
-  ),
-  (101, '2025-12-02 11:19:00', 'Akita', 'DOG'),
-  (102, '2025-12-02 11:19:00', 'Borzoi', 'DOG'),
-  (103, '2025-12-02 11:19:00', 'Chow Chow', 'DOG'),
-  (104, '2025-12-02 11:19:00', 'Afghan Hound', 'DOG'),
-  (105, '2025-12-02 11:19:00', 'Basenji', 'DOG'),
-  (
-    106,
-    '2025-12-02 11:19:00',
-    'Great Pyrenees',
-    'DOG'
-  ),
-  (
-    107,
-    '2025-12-02 11:19:00',
-    'Japanese Chin',
-    'DOG'
-  ),
-  (108, '2025-12-02 11:19:00', 'Keeshond', 'DOG'),
-  (109, '2025-12-02 11:19:00', 'Kuvasz', 'DOG'),
-  (
-    110,
-    '2025-12-02 11:19:00',
-    'Tibetan Mastiff',
-    'DOG'
-  ),
-  (
-    111,
-    '2025-12-02 11:19:00',
-    'Tibetan Terrier',
-    'DOG'
-  );
-
 /*!40000 ALTER TABLE `breed` ENABLE KEYS */;
 
 UNLOCK TABLES;

--- a/src/main/resources/db/migration/V1__vetlog_master.sql
+++ b/src/main/resources/db/migration/V1__vetlog_master.sql
@@ -3,227 +3,537 @@
 -- Host: localhost    Database: vetlog_spring_boot
 -- ------------------------------------------------------
 -- Server version	5.7.18-0ubuntu0.17.04.1
-
 /*!40101 SET @OLD_CHARACTER_SET_CLIENT=@@CHARACTER_SET_CLIENT */;
+
 /*!40101 SET @OLD_CHARACTER_SET_RESULTS=@@CHARACTER_SET_RESULTS */;
+
 /*!40101 SET @OLD_COLLATION_CONNECTION=@@COLLATION_CONNECTION */;
+
 /*!40101 SET NAMES utf8 */;
+
 /*!40103 SET @OLD_TIME_ZONE=@@TIME_ZONE */;
+
 /*!40103 SET TIME_ZONE='+00:00' */;
+
 /*!40014 SET @OLD_UNIQUE_CHECKS=@@UNIQUE_CHECKS, UNIQUE_CHECKS=0 */;
+
 /*!40014 SET @OLD_FOREIGN_KEY_CHECKS=@@FOREIGN_KEY_CHECKS, FOREIGN_KEY_CHECKS=0 */;
+
 /*!40101 SET @OLD_SQL_MODE=@@SQL_MODE, SQL_MODE='NO_AUTO_VALUE_ON_ZERO' */;
+
 /*!40111 SET @OLD_SQL_NOTES=@@SQL_NOTES, SQL_NOTES=0 */;
 
 --
 -- Table structure for table `registration_code`
 --
-
 DROP TABLE IF EXISTS `registration_code`;
+
 /*!40101 SET @saved_cs_client     = @@character_set_client */;
+
 /*!40101 SET character_set_client = utf8 */;
-CREATE TABLE `registration_code` (
-  `id` bigint(20) NOT NULL AUTO_INCREMENT,
-  `date_created` datetime NOT NULL,
-  `email` varchar(255) NOT NULL,
-  `status` int(11) NOT NULL,
-  `token` varchar(255) NOT NULL,
-  PRIMARY KEY (`id`)
-) ENGINE=InnoDB DEFAULT CHARSET=latin1;
+
+CREATE TABLE
+  `registration_code` (
+    `id` bigint (20) NOT NULL AUTO_INCREMENT,
+    `date_created` datetime NOT NULL,
+    `email` varchar(255) NOT NULL,
+    `status` int (11) NOT NULL,
+    `token` varchar(255) NOT NULL,
+    PRIMARY KEY (`id`)
+  ) ENGINE = InnoDB DEFAULT CHARSET = latin1;
+
 /*!40101 SET character_set_client = @saved_cs_client */;
 
 --
 -- Dumping data for table `registration_code`
 --
-
 LOCK TABLES `registration_code` WRITE;
+
 /*!40000 ALTER TABLE `registration_code` DISABLE KEYS */;
+
 /*!40000 ALTER TABLE `registration_code` ENABLE KEYS */;
+
 UNLOCK TABLES;
 
 --
 -- Table structure for table `breed`
 --
-
 DROP TABLE IF EXISTS `breed`;
+
 /*!40101 SET @saved_cs_client     = @@character_set_client */;
+
 /*!40101 SET character_set_client = utf8 */;
-CREATE TABLE `breed` (
-  `id` bigint(20) NOT NULL AUTO_INCREMENT,
-  `date_created` datetime NOT NULL,
-  `name` varchar(255) NOT NULL,
-  `type` varchar(255) NOT NULL,
-  PRIMARY KEY (`id`)
-) ENGINE=InnoDB AUTO_INCREMENT=70 DEFAULT CHARSET=latin1;
+
+CREATE TABLE
+  `breed` (
+    `id` bigint (20) NOT NULL AUTO_INCREMENT,
+    `date_created` datetime NOT NULL,
+    `name` varchar(255) NOT NULL,
+    `type` varchar(255) NOT NULL,
+    PRIMARY KEY (`id`)
+  ) ENGINE = InnoDB AUTO_INCREMENT = 70 DEFAULT CHARSET = latin1;
+
 /*!40101 SET character_set_client = @saved_cs_client */;
 
 --
 -- Dumping data for table `breed`
 --
-
 LOCK TABLES `breed` WRITE;
+
 /*!40000 ALTER TABLE `breed` DISABLE KEYS */;
-INSERT INTO `breed` VALUES (1,'2017-06-03 21:23:01','Labrador','DOG'),(2,'2017-06-03 21:23:01','Landrace','DOG'),(3,'2017-06-03 21:23:01','German Shepherd','DOG'),(4,'2017-06-03 21:23:01','Golden Retriever','DOG'),(5,'2017-06-03 21:23:01','Bulldog','DOG'),(6,'2017-06-03 21:23:01','Poodle','DOG'),(7,'2017-06-03 21:23:01','Beagle','DOG'),(8,'2017-06-03 21:23:01','Boxer','DOG'),(9,'2017-06-03 21:23:01','Yorkshire Terrier','DOG'),(10,'2017-06-03 21:23:01','Rottweiler','DOG'),(11,'2017-06-03 21:23:01','Chihuahua','DOG'),(12,'2017-06-03 21:23:01','Dachshund','DOG'),(13,'2017-06-03 21:23:01','French Bulldog','DOG'),(14,'2017-06-03 21:23:01','Shih Tzu','DOG'),(15,'2017-06-03 21:23:01','Pug','DOG'),(16,'2017-06-03 21:23:01','Siberian Husky','DOG'),(17,'2017-06-03 21:23:01','English Cocker Spaniel','DOG'),(18,'2017-06-03 21:23:01','Pomeranian','DOG'),(19,'2017-06-03 21:23:01','Cavalier King Charles Spaniel','DOG'),(20,'2017-06-03 21:23:01','Border Collie','DOG'),(21,'2017-06-03 21:23:01','Bull Terrier','DOG'),(22,'2017-06-03 21:23:01','Schnauzer','DOG'),(23,'2017-06-03 21:23:01','Great Dane','DOG'),(24,'2017-06-03 21:23:01','Bull Terrier','DOG'),(25,'2017-06-03 21:23:01','Old English Sheepdog','DOG'),(26,'2017-06-03 21:23:01','Doberman','DOG'),(27,'2017-06-03 21:23:01','Jack Russell Terrier','DOG'),(28,'2017-06-03 21:23:01','Maltese','DOG'),(29,'2017-06-03 21:23:01','Newfoundland dog','DOG'),(30,'2017-06-03 21:23:01','English Mastiff','DOG'),(31,'2017-06-03 21:23:01','Australian Shepherd','DOG'),(32,'2017-06-03 21:23:01','Boston Terrier','DOG'),(33,'2017-06-03 21:23:01','Havanese','DOG'),(34,'2017-06-03 21:23:01','Dalmatian','DOG'),(35,'2017-06-03 21:23:01','Pointer','DOG'),(36,'2017-06-03 21:23:01','St. Bernard','DOG'),(37,'2017-06-03 21:23:01','Pit bull','DOG'),(38,'2017-06-03 21:23:01','Weimaraner','DOG'),(39,'2017-06-03 21:23:01','Dogue de Bordeaux','DOG'),(40,'2017-06-03 21:23:01','Siamese','CAT'),(41,'2017-06-03 21:23:01','Landrace','CAT'),(42,'2017-06-03 21:23:01','British Shorthair','CAT'),(43,'2017-06-03 21:23:01','Persian','CAT'),(44,'2017-06-03 21:23:01','Maine Coon','CAT'),(45,'2017-06-03 21:23:01','Ragdoll','CAT'),(46,'2017-06-03 21:23:01','American Shorthair','CAT'),(47,'2017-06-03 21:23:01','Abyssinian','CAT'),(48,'2017-06-03 21:23:01','Burmese','CAT'),(49,'2017-06-03 21:23:01','Bengal','CAT'),(50,'2017-06-03 21:23:01','Sphynx','CAT'),(51,'2017-06-03 21:23:01','Birman','CAT'),(52,'2017-06-03 21:23:01','Scottish Fold','CAT'),(53,'2017-06-03 21:23:01','American Bobtail','CAT'),(54,'2017-06-03 21:23:01','Chicken','BIRD'),(55,'2017-06-03 21:23:01','Canary','BIRD'),(56,'2017-06-03 21:23:01','Duck','BIRD'),(57,'2017-06-03 21:23:01','Dove','BIRD'),(58,'2017-06-03 21:23:01','Goose','BIRD'),(59,'2017-06-03 21:23:01','Swan','BIRD'),(60,'2017-06-03 21:23:01','Guinea pig','RODENT'),(61,'2017-06-03 21:23:01','Hamster','RODENT'),(62,'2017-06-03 21:23:01','Chinchillas','RODENT'),(63,'2017-06-03 21:23:01','Rabbit','RODENT'),(64,'2017-06-03 21:23:01','Corn Snake','SNAKE'),(65,'2017-06-03 21:23:01','Kingsnake','SNAKE'),(66,'2017-06-03 21:23:01','Rosy Boa','SNAKE'),(67,'2017-06-03 21:23:01','Gopher','SNAKE'),(68,'2017-06-03 21:23:01','Ball Python','SNAKE'),(69,'2017-06-03 21:23:01','Tarantula','SPIDER');
+
+INSERT INTO
+  `breed`
+VALUES
+  (1, '2017-06-03 21:23:01', 'Labrador', 'DOG'),
+  (2, '2017-06-03 21:23:01', 'Landrace', 'DOG'),
+  (
+    3,
+    '2017-06-03 21:23:01',
+    'German Shepherd',
+    'DOG'
+  ),
+  (
+    4,
+    '2017-06-03 21:23:01',
+    'Golden Retriever',
+    'DOG'
+  ),
+  (5, '2017-06-03 21:23:01', 'Bulldog', 'DOG'),
+  (6, '2017-06-03 21:23:01', 'Poodle', 'DOG'),
+  (7, '2017-06-03 21:23:01', 'Beagle', 'DOG'),
+  (8, '2017-06-03 21:23:01', 'Boxer', 'DOG'),
+  (
+    9,
+    '2017-06-03 21:23:01',
+    'Yorkshire Terrier',
+    'DOG'
+  ),
+  (10, '2017-06-03 21:23:01', 'Rottweiler', 'DOG'),
+  (11, '2017-06-03 21:23:01', 'Chihuahua', 'DOG'),
+  (12, '2017-06-03 21:23:01', 'Dachshund', 'DOG'),
+  (
+    13,
+    '2017-06-03 21:23:01',
+    'French Bulldog',
+    'DOG'
+  ),
+  (14, '2017-06-03 21:23:01', 'Shih Tzu', 'DOG'),
+  (15, '2017-06-03 21:23:01', 'Pug', 'DOG'),
+  (
+    16,
+    '2017-06-03 21:23:01',
+    'Siberian Husky',
+    'DOG'
+  ),
+  (
+    17,
+    '2017-06-03 21:23:01',
+    'English Cocker Spaniel',
+    'DOG'
+  ),
+  (18, '2017-06-03 21:23:01', 'Pomeranian', 'DOG'),
+  (
+    19,
+    '2017-06-03 21:23:01',
+    'Cavalier King Charles Spaniel',
+    'DOG'
+  ),
+  (20, '2017-06-03 21:23:01', 'Border Collie', 'DOG'),
+  (21, '2017-06-03 21:23:01', 'Bull Terrier', 'DOG'),
+  (22, '2017-06-03 21:23:01', 'Schnauzer', 'DOG'),
+  (23, '2017-06-03 21:23:01', 'Great Dane', 'DOG'),
+  (24, '2017-06-03 21:23:01', 'Bull Terrier', 'DOG'),
+  (
+    25,
+    '2017-06-03 21:23:01',
+    'Old English Sheepdog',
+    'DOG'
+  ),
+  (26, '2017-06-03 21:23:01', 'Doberman', 'DOG'),
+  (
+    27,
+    '2017-06-03 21:23:01',
+    'Jack Russell Terrier',
+    'DOG'
+  ),
+  (28, '2017-06-03 21:23:01', 'Maltese', 'DOG'),
+  (
+    29,
+    '2017-06-03 21:23:01',
+    'Newfoundland dog',
+    'DOG'
+  ),
+  (
+    30,
+    '2017-06-03 21:23:01',
+    'English Mastiff',
+    'DOG'
+  ),
+  (
+    31,
+    '2017-06-03 21:23:01',
+    'Australian Shepherd',
+    'DOG'
+  ),
+  (
+    32,
+    '2017-06-03 21:23:01',
+    'Boston Terrier',
+    'DOG'
+  ),
+  (33, '2017-06-03 21:23:01', 'Havanese', 'DOG'),
+  (34, '2017-06-03 21:23:01', 'Dalmatian', 'DOG'),
+  (35, '2017-06-03 21:23:01', 'Pointer', 'DOG'),
+  (36, '2017-06-03 21:23:01', 'St. Bernard', 'DOG'),
+  (37, '2017-06-03 21:23:01', 'Pit bull', 'DOG'),
+  (38, '2017-06-03 21:23:01', 'Weimaraner', 'DOG'),
+  (
+    39,
+    '2017-06-03 21:23:01',
+    'Dogue de Bordeaux',
+    'DOG'
+  ),
+  (40, '2017-06-03 21:23:01', 'Siamese', 'CAT'),
+  (41, '2017-06-03 21:23:01', 'Landrace', 'CAT'),
+  (
+    42,
+    '2017-06-03 21:23:01',
+    'British Shorthair',
+    'CAT'
+  ),
+  (43, '2017-06-03 21:23:01', 'Persian', 'CAT'),
+  (44, '2017-06-03 21:23:01', 'Maine Coon', 'CAT'),
+  (45, '2017-06-03 21:23:01', 'Ragdoll', 'CAT'),
+  (
+    46,
+    '2017-06-03 21:23:01',
+    'American Shorthair',
+    'CAT'
+  ),
+  (47, '2017-06-03 21:23:01', 'Abyssinian', 'CAT'),
+  (48, '2017-06-03 21:23:01', 'Burmese', 'CAT'),
+  (49, '2017-06-03 21:23:01', 'Bengal', 'CAT'),
+  (50, '2017-06-03 21:23:01', 'Sphynx', 'CAT'),
+  (51, '2017-06-03 21:23:01', 'Birman', 'CAT'),
+  (52, '2017-06-03 21:23:01', 'Scottish Fold', 'CAT'),
+  (
+    53,
+    '2017-06-03 21:23:01',
+    'American Bobtail',
+    'CAT'
+  ),
+  (54, '2017-06-03 21:23:01', 'Chicken', 'BIRD'),
+  (55, '2017-06-03 21:23:01', 'Canary', 'BIRD'),
+  (56, '2017-06-03 21:23:01', 'Duck', 'BIRD'),
+  (57, '2017-06-03 21:23:01', 'Dove', 'BIRD'),
+  (58, '2017-06-03 21:23:01', 'Goose', 'BIRD'),
+  (59, '2017-06-03 21:23:01', 'Swan', 'BIRD'),
+  (60, '2017-06-03 21:23:01', 'Guinea pig', 'RODENT'),
+  (61, '2017-06-03 21:23:01', 'Hamster', 'RODENT'),
+  (
+    62,
+    '2017-06-03 21:23:01',
+    'Chinchillas',
+    'RODENT'
+  ),
+  (63, '2017-06-03 21:23:01', 'Rabbit', 'RODENT'),
+  (64, '2017-06-03 21:23:01', 'Corn Snake', 'SNAKE'),
+  (65, '2017-06-03 21:23:01', 'Kingsnake', 'SNAKE'),
+  (66, '2017-06-03 21:23:01', 'Rosy Boa', 'SNAKE'),
+  (67, '2017-06-03 21:23:01', 'Gopher', 'SNAKE'),
+  (68, '2017-06-03 21:23:01', 'Ball Python', 'SNAKE'),
+  (69, '2017-06-03 21:23:01', 'Tarantula', 'SPIDER');
+
+INSERT INTO
+  `breed`
+VALUES
+  (
+    80,
+    '2025-02-12 11:14:23',
+    'Australian Cattle',
+    'DOG'
+  ),
+  (
+    81,
+    '2025-03-12 11:14:23',
+    'Miniature Pinscher',
+    'DOG'
+  ),
+  (82, '2025-02-12 11:14:23', 'Goldendoodle', 'DOG'),
+  (83, '2025-02-12 11:14:23', 'Schnoodle', 'DOG'),
+  (
+    84,
+    '2025-12-02 11:19:00',
+    'Alaskan Malamute',
+    'DOG'
+  ),
+  (
+    85,
+    '2025-12-02 11:19:00',
+    'Bernese Mountain Dog',
+    'DOG'
+  ),
+  (86, '2025-12-02 11:19:00', 'Basset Hound', 'DOG'),
+  (87, '2025-12-02 11:19:00', 'Cane Corso', 'DOG'),
+  (88, '2025-12-02 11:19:00', 'Collie', 'DOG'),
+  (89, '2025-12-02 11:19:00', 'Irish Setter', 'DOG'),
+  (
+    90,
+    '2025-12-02 11:19:00',
+    'Italian Greyhound',
+    'DOG'
+  ),
+  (91, '2025-12-02 11:19:00', 'Lhasa Apso', 'DOG'),
+  (
+    92,
+    '2025-12-02 11:19:00',
+    'Norwegian Elkhound',
+    'DOG'
+  ),
+  (93, '2025-12-02 11:19:00', 'Papillon', 'DOG'),
+  (94, '2025-12-02 11:19:00', 'Samoyed', 'DOG'),
+  (95, '2025-12-02 11:19:00', 'Shar Pei', 'DOG'),
+  (
+    96,
+    '2025-12-02 11:19:00',
+    'Springer Spaniel',
+    'DOG'
+  ),
+  (
+    97,
+    '2025-12-02 11:19:00',
+    'Staffordshire Bull Terrier',
+    'DOG'
+  ),
+  (98, '2025-12-02 11:19:00', 'Vizsla', 'DOG'),
+  (99, '2025-12-02 11:19:00', 'Whippet', 'DOG'),
+  (
+    100,
+    '2025-12-02 11:19:00',
+    'West Highland White Terrier',
+    'DOG'
+  ),
+  (101, '2025-12-02 11:19:00', 'Akita', 'DOG'),
+  (102, '2025-12-02 11:19:00', 'Borzoi', 'DOG'),
+  (103, '2025-12-02 11:19:00', 'Chow Chow', 'DOG'),
+  (104, '2025-12-02 11:19:00', 'Afghan Hound', 'DOG'),
+  (105, '2025-12-02 11:19:00', 'Basenji', 'DOG'),
+  (
+    106,
+    '2025-12-02 11:19:00',
+    'Great Pyrenees',
+    'DOG'
+  ),
+  (
+    107,
+    '2025-12-02 11:19:00',
+    'Japanese Chin',
+    'DOG'
+  ),
+  (108, '2025-12-02 11:19:00', 'Keeshond', 'DOG'),
+  (109, '2025-12-02 11:19:00', 'Kuvasz', 'DOG'),
+  (
+    110,
+    '2025-12-02 11:19:00',
+    'Tibetan Mastiff',
+    'DOG'
+  ),
+  (
+    111,
+    '2025-12-02 11:19:00',
+    'Tibetan Terrier',
+    'DOG'
+  );
+
 /*!40000 ALTER TABLE `breed` ENABLE KEYS */;
+
 UNLOCK TABLES;
 
 --
 -- Table structure for table `user`
 --
-
 DROP TABLE IF EXISTS `user`;
+
 /*!40101 SET @saved_cs_client     = @@character_set_client */;
+
 /*!40101 SET character_set_client = utf8 */;
-CREATE TABLE `user` (
-  `id` bigint(20) NOT NULL AUTO_INCREMENT,
-  `account_non_expired` bit(1) NOT NULL,
-  `account_non_locked` bit(1) NOT NULL,
-  `credentials_non_expired` bit(1) NOT NULL,
-  `date_created` datetime NOT NULL,
-  `email` varchar(255) DEFAULT NULL,
-  `enabled` bit(1) NOT NULL,
-  `mobile` varchar(255) DEFAULT NULL,
-  `password` varchar(255) NOT NULL,
-  `role` varchar(255) NOT NULL,
-  `username` varchar(255) NOT NULL,
-  `first_name` varchar(255) DEFAULT NULL,
-  `last_name` varchar(255) DEFAULT NULL,
-  PRIMARY KEY (`id`),
-  UNIQUE KEY `UK_sb8bbouer5wak8vyiiy4pf2bx` (`username`)
-) ENGINE=InnoDB AUTO_INCREMENT=4 DEFAULT CHARSET=latin1;
+
+CREATE TABLE
+  `user` (
+    `id` bigint (20) NOT NULL AUTO_INCREMENT,
+    `account_non_expired` bit (1) NOT NULL,
+    `account_non_locked` bit (1) NOT NULL,
+    `credentials_non_expired` bit (1) NOT NULL,
+    `date_created` datetime NOT NULL,
+    `email` varchar(255) DEFAULT NULL,
+    `enabled` bit (1) NOT NULL,
+    `mobile` varchar(255) DEFAULT NULL,
+    `password` varchar(255) NOT NULL,
+    `role` varchar(255) NOT NULL,
+    `username` varchar(255) NOT NULL,
+    `first_name` varchar(255) DEFAULT NULL,
+    `last_name` varchar(255) DEFAULT NULL,
+    PRIMARY KEY (`id`),
+    UNIQUE KEY `UK_sb8bbouer5wak8vyiiy4pf2bx` (`username`)
+  ) ENGINE = InnoDB AUTO_INCREMENT = 4 DEFAULT CHARSET = latin1;
+
 /*!40101 SET character_set_client = @saved_cs_client */;
 
 --
 -- Dumping data for table `user`
 --
-
 --
 -- Table structure for table `pet`
 --
-
 DROP TABLE IF EXISTS `pet`;
+
 /*!40101 SET @saved_cs_client     = @@character_set_client */;
+
 /*!40101 SET character_set_client = utf8 */;
-CREATE TABLE `pet` (
-  `id` bigint(20) NOT NULL AUTO_INCREMENT,
-  `birth_date` datetime NOT NULL,
-  `date_created` datetime NOT NULL,
-  `dewormed` bit(1) NOT NULL,
-  `name` varchar(255) NOT NULL,
-  `status` varchar(255) NOT NULL,
-  `sterilized` bit(1) NOT NULL,
-  `uuid` varchar(255) NOT NULL,
-  `vaccinated` bit(1) NOT NULL,
-  `adopter_id` bigint(20) DEFAULT NULL,
-  `breed_id` bigint(20) DEFAULT NULL,
-  `user_id` bigint(20) DEFAULT NULL,
-  `pet_id` bigint DEFAULT NULL,
-  PRIMARY KEY (`id`),
-  KEY `FKj3j9664ee510hnt2pkd7on7dl` (`adopter_id`),
-  KEY `FKiqbjbaml7gtwulqptktmsi5dc` (`breed_id`),
-  KEY `FK9hxka0oqkd15dmqstdarori08` (`user_id`),
-  CONSTRAINT `FK9hxka0oqkd15dmqstdarori08` FOREIGN KEY (`user_id`) REFERENCES `user` (`id`),
-  CONSTRAINT `FKiqbjbaml7gtwulqptktmsi5dc` FOREIGN KEY (`breed_id`) REFERENCES `breed` (`id`),
-  CONSTRAINT `FKj3j9664ee510hnt2pkd7on7dl` FOREIGN KEY (`adopter_id`) REFERENCES `user` (`id`)
-) ENGINE=InnoDB AUTO_INCREMENT=2 DEFAULT CHARSET=latin1;
+
+CREATE TABLE
+  `pet` (
+    `id` bigint (20) NOT NULL AUTO_INCREMENT,
+    `birth_date` datetime NOT NULL,
+    `date_created` datetime NOT NULL,
+    `dewormed` bit (1) NOT NULL,
+    `name` varchar(255) NOT NULL,
+    `status` varchar(255) NOT NULL,
+    `sterilized` bit (1) NOT NULL,
+    `uuid` varchar(255) NOT NULL,
+    `vaccinated` bit (1) NOT NULL,
+    `adopter_id` bigint (20) DEFAULT NULL,
+    `breed_id` bigint (20) DEFAULT NULL,
+    `user_id` bigint (20) DEFAULT NULL,
+    `pet_id` bigint DEFAULT NULL,
+    PRIMARY KEY (`id`),
+    KEY `FKj3j9664ee510hnt2pkd7on7dl` (`adopter_id`),
+    KEY `FKiqbjbaml7gtwulqptktmsi5dc` (`breed_id`),
+    KEY `FK9hxka0oqkd15dmqstdarori08` (`user_id`),
+    CONSTRAINT `FK9hxka0oqkd15dmqstdarori08` FOREIGN KEY (`user_id`) REFERENCES `user` (`id`),
+    CONSTRAINT `FKiqbjbaml7gtwulqptktmsi5dc` FOREIGN KEY (`breed_id`) REFERENCES `breed` (`id`),
+    CONSTRAINT `FKj3j9664ee510hnt2pkd7on7dl` FOREIGN KEY (`adopter_id`) REFERENCES `user` (`id`)
+  ) ENGINE = InnoDB AUTO_INCREMENT = 2 DEFAULT CHARSET = latin1;
+
 /*!40101 SET character_set_client = @saved_cs_client */;
 
 --
 -- Dumping data for table `pet`
 --
-
-
 --
 -- Table structure for table `pet_adoption`
 --
-
 DROP TABLE IF EXISTS `pet_adoption`;
+
 /*!40101 SET @saved_cs_client     = @@character_set_client */;
+
 /*!40101 SET character_set_client = utf8 */;
-CREATE TABLE `pet_adoption` (
-  `id` bigint(20) NOT NULL AUTO_INCREMENT,
-  `description` text NOT NULL,
-  `pet_id` bigint(20) DEFAULT NULL,
-  PRIMARY KEY (`id`),
-  KEY `FK939up3l91l7c779k1qlg9qhul` (`pet_id`),
-  CONSTRAINT `FK939up3l91l7c779k1qlg9qhul` FOREIGN KEY (`pet_id`) REFERENCES `pet` (`id`)
-) ENGINE=InnoDB DEFAULT CHARSET=latin1;
+
+CREATE TABLE
+  `pet_adoption` (
+    `id` bigint (20) NOT NULL AUTO_INCREMENT,
+    `description` text NOT NULL,
+    `pet_id` bigint (20) DEFAULT NULL,
+    PRIMARY KEY (`id`),
+    KEY `FK939up3l91l7c779k1qlg9qhul` (`pet_id`),
+    CONSTRAINT `FK939up3l91l7c779k1qlg9qhul` FOREIGN KEY (`pet_id`) REFERENCES `pet` (`id`)
+  ) ENGINE = InnoDB DEFAULT CHARSET = latin1;
+
 /*!40101 SET character_set_client = @saved_cs_client */;
 
 --
 -- Dumping data for table `pet_adoption`
 --
-
 LOCK TABLES `pet_adoption` WRITE;
+
 /*!40000 ALTER TABLE `pet_adoption` DISABLE KEYS */;
+
 /*!40000 ALTER TABLE `pet_adoption` ENABLE KEYS */;
+
 UNLOCK TABLES;
 
 --
 -- Table structure for table `pet_image`
 --
-
 DROP TABLE IF EXISTS `pet_image`;
+
 /*!40101 SET @saved_cs_client     = @@character_set_client */;
+
 /*!40101 SET character_set_client = utf8 */;
-CREATE TABLE `pet_image` (
-  `id` bigint(20) NOT NULL AUTO_INCREMENT,
-  `uuid` varchar(255) NOT NULL,
-  `pet_image_id` bigint(20) DEFAULT NULL,
-  PRIMARY KEY (`id`),
-  KEY `FKnf9loskcjkxo9f2qafq08dyvp` (`pet_image_id`),
-  CONSTRAINT `FKnf9loskcjkxo9f2qafq08dyvp` FOREIGN KEY (`pet_image_id`) REFERENCES `pet` (`id`)
-) ENGINE=InnoDB DEFAULT CHARSET=latin1;
+
+CREATE TABLE
+  `pet_image` (
+    `id` bigint (20) NOT NULL AUTO_INCREMENT,
+    `uuid` varchar(255) NOT NULL,
+    `pet_image_id` bigint (20) DEFAULT NULL,
+    PRIMARY KEY (`id`),
+    KEY `FKnf9loskcjkxo9f2qafq08dyvp` (`pet_image_id`),
+    CONSTRAINT `FKnf9loskcjkxo9f2qafq08dyvp` FOREIGN KEY (`pet_image_id`) REFERENCES `pet` (`id`)
+  ) ENGINE = InnoDB DEFAULT CHARSET = latin1;
+
 /*!40101 SET character_set_client = @saved_cs_client */;
 
 --
 -- Dumping data for table `pet_image`
 --
-
 LOCK TABLES `pet_image` WRITE;
+
 /*!40000 ALTER TABLE `pet_image` DISABLE KEYS */;
+
 /*!40000 ALTER TABLE `pet_image` ENABLE KEYS */;
+
 UNLOCK TABLES;
 
 --
 -- Table structure for table `pet_log`
 --
-
 DROP TABLE IF EXISTS `pet_log`;
+
 /*!40101 SET @saved_cs_client     = @@character_set_client */;
+
 /*!40101 SET character_set_client = utf8 */;
-CREATE TABLE `pet_log` (
-  `id` bigint(20) NOT NULL AUTO_INCREMENT,
-  `date_created` datetime NOT NULL,
-  `diagnosis` varchar(1000) NOT NULL,
-  `medicine` varchar(1000) DEFAULT NULL,
-  `signs` varchar(1000) NOT NULL,
-  `vet_name` varchar(255) DEFAULT NULL,
-  `pet_id` bigint(20) DEFAULT NULL,
-  `uuid` varchar(255) NOT NULL,
-  PRIMARY KEY (`id`),
-  KEY `FK6qt0o586ujuoupfj1gnnw3yjp` (`pet_id`),
-  CONSTRAINT `FK6qt0o586ujuoupfj1gnnw3yjp` FOREIGN KEY (`pet_id`) REFERENCES `pet` (`id`)
-) ENGINE=InnoDB DEFAULT CHARSET=latin1;
+
+CREATE TABLE
+  `pet_log` (
+    `id` bigint (20) NOT NULL AUTO_INCREMENT,
+    `date_created` datetime NOT NULL,
+    `diagnosis` varchar(1000) NOT NULL,
+    `medicine` varchar(1000) DEFAULT NULL,
+    `signs` varchar(1000) NOT NULL,
+    `vet_name` varchar(255) DEFAULT NULL,
+    `pet_id` bigint (20) DEFAULT NULL,
+    `uuid` varchar(255) NOT NULL,
+    PRIMARY KEY (`id`),
+    KEY `FK6qt0o586ujuoupfj1gnnw3yjp` (`pet_id`),
+    CONSTRAINT `FK6qt0o586ujuoupfj1gnnw3yjp` FOREIGN KEY (`pet_id`) REFERENCES `pet` (`id`)
+  ) ENGINE = InnoDB DEFAULT CHARSET = latin1;
+
 /*!40101 SET character_set_client = @saved_cs_client */;
 
 --
 -- Dumping data for table `pet_log`
 --
-
 LOCK TABLES `pet_log` WRITE;
+
 /*!40000 ALTER TABLE `pet_log` DISABLE KEYS */;
+
 /*!40000 ALTER TABLE `pet_log` ENABLE KEYS */;
+
 UNLOCK TABLES;
 
 DROP TABLE IF EXISTS `pet_medicine`;
+
 /*!40101 SET @saved_cs_client     = @@character_set_client */;
+
 /*!40101 SET character_set_client = utf8 */;
-CREATE TABLE `pet_medicine` (
-    `id` bigint(20) NOT NULL AUTO_INCREMENT,
+
+CREATE TABLE
+  `pet_medicine` (
+    `id` bigint (20) NOT NULL AUTO_INCREMENT,
     `uuid` varchar(255) NOT NULL,
-    `pet_medicine_id` bigint(20) DEFAULT NULL,
+    `pet_medicine_id` bigint (20) DEFAULT NULL,
     PRIMARY KEY (`id`),
     KEY `FKnf9loskcjkxo9f2qafq08dyjm` (`pet_medicine_id`),
     CONSTRAINT `FKnf9loskcjkxo9f2qafq08dyjm` FOREIGN KEY (`pet_medicine_id`) REFERENCES `pet` (`id`)
-) ENGINE=InnoDB DEFAULT CHARSET=latin1;
+  ) ENGINE = InnoDB DEFAULT CHARSET = latin1;

--- a/src/main/resources/i18n/messages_es.properties
+++ b/src/main/resources/i18n/messages_es.properties
@@ -1,6 +1,6 @@
 app.title=Vetlog
 app.mailto=mailto:vetlog@josdem.io
-app.contact.us=ContactÃ¡ctanos Us: vetlog@josdem.io
+app.contact.us=ContactÃ¡ctanos: vetlog@josdem.io
 app.description=SÃ³lo en MÃ©xico 500,000 perros son sacrificados cada aÃ±o. Â¡AyÃºdanos a decrementar esa cifra!
 
 home.user.title=Â¿EstÃ¡s listo(a) para registrarte?
@@ -53,7 +53,7 @@ user.mobile=NÃºmero de TelÃ©fono
 user.email=Correo ElectrÃ³nico
 user.account.created=Tu cuenta fue creada.
 user.error.mobile=NÃºmero telefÃ³nico no vÃ¡lido
-user.welcome.message=Registrar todas tus mascotas y su historial médico, también podrás encontrar mascotas en adopción así como publicar mascotas buscando una nueva familia.
+user.welcome.message=Registrar todas tus mascotas y su historial mï¿½dico, tambiï¿½n podrï¿½s encontrar mascotas en adopciï¿½n asï¿½ como publicar mascotas buscando una nueva familia.
 user.not.found=Parece que no tenemos un usuario registrado bajo ese email
 
 recovery.password.view.title=Recuperar ContraseÃ±a
@@ -124,13 +124,13 @@ vet.search.username=Buscar mascotas por usuario
 
 privacy.title=Aviso de Privacidad
 privacy.header=Bienvenidos al aviso de privacidad de Vetlog
-privacy.description=Vetlog es una aplicación web ó sitio web, que te permite registrar tus mascotas y su historial médico. Estamos comprometidos a proteger tu privacidad. Esta Política de Privacidad explica cómo recopilamos, usamos, divulgamos y protegemos tu información cuando visitas nuestro sitio web. Por favor, lee esta Política de Privacidad cuidadosamente. SI NO ESTÁS DE ACUERDO CON LOS TÉRMINOS DE ESTA POLÍTICA DE PRIVACIDAD, POR FAVOR NO ACCEDAS AL SITIO.
-privacy.information.title=Información que Recopilamos
-privacy.information.description=Recopilamos información personal que nos proporcionas voluntariamente al registrarte en el sitio web expresando interés en obtener información sobre nosotros o nuestros servicios, al participar en actividades en el sitio web.
-privacy.usage.title=Uso de tu Información
-privacy.usage.description=Tener información precisa sobre ti y tus mascotas nos permite proporcionarte una buena experiencia, eficiente y personalizada. Específicamente, podemos usar la información recopilada sobre ti a través del sitio web para:
-privacy.usage.list=Crear y administrar tu cuenta y el historial médico de tus mascotas.
-privacy.disclosure.title=Divulgación de tu Información
-privacy.disclosure.description=No compartiremos ninguna información que hayamos recopilado sobre ti o tus mascotas con ninguna entidad de terceros.
-privacy.security.title=Seguridad de tu Información
-privacy.security.description=Usamos autenticación, autorización y filtros para manejar el acceso de los usuarios al sitio web, no conocemos tu contraseña, ya que usamos la función de hash BCrypt para almacenarlas, y otras medidas de seguridad estándar para ayudar a proteger tu información personal. Por la presente declaramos, según nuestro leal saber y entender, que tu información está segura. Si encuentras alguna vulnerabilidad de seguridad que haya sido causada inadvertidamente por nosotros, o tienes alguna pregunta sobre cómo el sitio web protege tu privacidad, por favor contáctanos en vetlog@josdem.io y con gusto te apoyamos.
+privacy.description=Vetlog es una aplicaciï¿½n web ï¿½ sitio web, que te permite registrar tus mascotas y su historial mï¿½dico. Estamos comprometidos a proteger tu privacidad. Esta Polï¿½tica de Privacidad explica cï¿½mo recopilamos, usamos, divulgamos y protegemos tu informaciï¿½n cuando visitas nuestro sitio web. Por favor, lee esta Polï¿½tica de Privacidad cuidadosamente. SI NO ESTï¿½S DE ACUERDO CON LOS Tï¿½RMINOS DE ESTA POLï¿½TICA DE PRIVACIDAD, POR FAVOR NO ACCEDAS AL SITIO.
+privacy.information.title=Informaciï¿½n que Recopilamos
+privacy.information.description=Recopilamos informaciï¿½n personal que nos proporcionas voluntariamente al registrarte en el sitio web expresando interï¿½s en obtener informaciï¿½n sobre nosotros o nuestros servicios, al participar en actividades en el sitio web.
+privacy.usage.title=Uso de tu Informaciï¿½n
+privacy.usage.description=Tener informaciï¿½n precisa sobre ti y tus mascotas nos permite proporcionarte una buena experiencia, eficiente y personalizada. Especï¿½ficamente, podemos usar la informaciï¿½n recopilada sobre ti a travï¿½s del sitio web para:
+privacy.usage.list=Crear y administrar tu cuenta y el historial mï¿½dico de tus mascotas.
+privacy.disclosure.title=Divulgaciï¿½n de tu Informaciï¿½n
+privacy.disclosure.description=No compartiremos ninguna informaciï¿½n que hayamos recopilado sobre ti o tus mascotas con ninguna entidad de terceros.
+privacy.security.title=Seguridad de tu Informaciï¿½n
+privacy.security.description=Usamos autenticaciï¿½n, autorizaciï¿½n y filtros para manejar el acceso de los usuarios al sitio web, no conocemos tu contraseï¿½a, ya que usamos la funciï¿½n de hash BCrypt para almacenarlas, y otras medidas de seguridad estï¿½ndar para ayudar a proteger tu informaciï¿½n personal. Por la presente declaramos, segï¿½n nuestro leal saber y entender, que tu informaciï¿½n estï¿½ segura. Si encuentras alguna vulnerabilidad de seguridad que haya sido causada inadvertidamente por nosotros, o tienes alguna pregunta sobre cï¿½mo el sitio web protege tu privacidad, por favor contï¿½ctanos en vetlog@josdem.io y con gusto te apoyamos.

--- a/src/main/resources/i18n/messages_es.properties
+++ b/src/main/resources/i18n/messages_es.properties
@@ -1,6 +1,6 @@
 app.title=Vetlog
 app.mailto=mailto:vetlog@josdem.io
-app.contact.us=ContactÃ¡ctanos: vetlog@josdem.io
+app.contact.us=ContactÃ¡ctanos Us: vetlog@josdem.io
 app.description=SÃ³lo en MÃ©xico 500,000 perros son sacrificados cada aÃ±o. Â¡AyÃºdanos a decrementar esa cifra!
 
 home.user.title=Â¿EstÃ¡s listo(a) para registrarte?
@@ -53,7 +53,7 @@ user.mobile=NÃºmero de TelÃ©fono
 user.email=Correo ElectrÃ³nico
 user.account.created=Tu cuenta fue creada.
 user.error.mobile=NÃºmero telefÃ³nico no vÃ¡lido
-user.welcome.message=Registrar todas tus mascotas y su historial mï¿½dico, tambiï¿½n podrï¿½s encontrar mascotas en adopciï¿½n asï¿½ como publicar mascotas buscando una nueva familia.
+user.welcome.message=Registrar todas tus mascotas y su historial médico, también podrás encontrar mascotas en adopción así como publicar mascotas buscando una nueva familia.
 user.not.found=Parece que no tenemos un usuario registrado bajo ese email
 
 recovery.password.view.title=Recuperar ContraseÃ±a
@@ -124,13 +124,13 @@ vet.search.username=Buscar mascotas por usuario
 
 privacy.title=Aviso de Privacidad
 privacy.header=Bienvenidos al aviso de privacidad de Vetlog
-privacy.description=Vetlog es una aplicaciï¿½n web ï¿½ sitio web, que te permite registrar tus mascotas y su historial mï¿½dico. Estamos comprometidos a proteger tu privacidad. Esta Polï¿½tica de Privacidad explica cï¿½mo recopilamos, usamos, divulgamos y protegemos tu informaciï¿½n cuando visitas nuestro sitio web. Por favor, lee esta Polï¿½tica de Privacidad cuidadosamente. SI NO ESTï¿½S DE ACUERDO CON LOS Tï¿½RMINOS DE ESTA POLï¿½TICA DE PRIVACIDAD, POR FAVOR NO ACCEDAS AL SITIO.
-privacy.information.title=Informaciï¿½n que Recopilamos
-privacy.information.description=Recopilamos informaciï¿½n personal que nos proporcionas voluntariamente al registrarte en el sitio web expresando interï¿½s en obtener informaciï¿½n sobre nosotros o nuestros servicios, al participar en actividades en el sitio web.
-privacy.usage.title=Uso de tu Informaciï¿½n
-privacy.usage.description=Tener informaciï¿½n precisa sobre ti y tus mascotas nos permite proporcionarte una buena experiencia, eficiente y personalizada. Especï¿½ficamente, podemos usar la informaciï¿½n recopilada sobre ti a travï¿½s del sitio web para:
-privacy.usage.list=Crear y administrar tu cuenta y el historial mï¿½dico de tus mascotas.
-privacy.disclosure.title=Divulgaciï¿½n de tu Informaciï¿½n
-privacy.disclosure.description=No compartiremos ninguna informaciï¿½n que hayamos recopilado sobre ti o tus mascotas con ninguna entidad de terceros.
-privacy.security.title=Seguridad de tu Informaciï¿½n
-privacy.security.description=Usamos autenticaciï¿½n, autorizaciï¿½n y filtros para manejar el acceso de los usuarios al sitio web, no conocemos tu contraseï¿½a, ya que usamos la funciï¿½n de hash BCrypt para almacenarlas, y otras medidas de seguridad estï¿½ndar para ayudar a proteger tu informaciï¿½n personal. Por la presente declaramos, segï¿½n nuestro leal saber y entender, que tu informaciï¿½n estï¿½ segura. Si encuentras alguna vulnerabilidad de seguridad que haya sido causada inadvertidamente por nosotros, o tienes alguna pregunta sobre cï¿½mo el sitio web protege tu privacidad, por favor contï¿½ctanos en vetlog@josdem.io y con gusto te apoyamos.
+privacy.description=Vetlog es una aplicación web ó sitio web, que te permite registrar tus mascotas y su historial médico. Estamos comprometidos a proteger tu privacidad. Esta Política de Privacidad explica cómo recopilamos, usamos, divulgamos y protegemos tu información cuando visitas nuestro sitio web. Por favor, lee esta Política de Privacidad cuidadosamente. SI NO ESTÁS DE ACUERDO CON LOS TÉRMINOS DE ESTA POLÍTICA DE PRIVACIDAD, POR FAVOR NO ACCEDAS AL SITIO.
+privacy.information.title=Información que Recopilamos
+privacy.information.description=Recopilamos información personal que nos proporcionas voluntariamente al registrarte en el sitio web expresando interés en obtener información sobre nosotros o nuestros servicios, al participar en actividades en el sitio web.
+privacy.usage.title=Uso de tu Información
+privacy.usage.description=Tener información precisa sobre ti y tus mascotas nos permite proporcionarte una buena experiencia, eficiente y personalizada. Específicamente, podemos usar la información recopilada sobre ti a través del sitio web para:
+privacy.usage.list=Crear y administrar tu cuenta y el historial médico de tus mascotas.
+privacy.disclosure.title=Divulgación de tu Información
+privacy.disclosure.description=No compartiremos ninguna información que hayamos recopilado sobre ti o tus mascotas con ninguna entidad de terceros.
+privacy.security.title=Seguridad de tu Información
+privacy.security.description=Usamos autenticación, autorización y filtros para manejar el acceso de los usuarios al sitio web, no conocemos tu contraseña, ya que usamos la función de hash BCrypt para almacenarlas, y otras medidas de seguridad estándar para ayudar a proteger tu información personal. Por la presente declaramos, según nuestro leal saber y entender, que tu información está segura. Si encuentras alguna vulnerabilidad de seguridad que haya sido causada inadvertidamente por nosotros, o tienes alguna pregunta sobre cómo el sitio web protege tu privacidad, por favor contáctanos en vetlog@josdem.io y con gusto te apoyamos.

--- a/src/main/resources/templates/fragments/footer.html
+++ b/src/main/resources/templates/fragments/footer.html
@@ -1,66 +1,31 @@
 <html>
   <footer>
-    <div class="container">
-      <p></p>
-      <div class="row">
-        <div class="col-md-12 col-sm-12 text-center">
-          <a th:href="@{/}"><i th:text="#{home.name}" /></a> |
-          <a th:href="@{/pet/list}"><i th:text="#{home.list.name}" /></a> |
-          <a th:href="@{/pet/create}"><i th:text="#{home.register.name}" /></a>
-          |
-          <a th:href="@{/pet/giveForAdoption}"
-            ><i th:text="#{adoption.name}"
-          /></a>
-          |
-          <a th:href="@{/privacy/show}"><i th:text="#{privacy.title}" /></a>
-        </div>
-      </div>
-      <div class="row margin-top">
-        <div class="col-md-12 col-sm-12 text-center">
-          <a href="https://twitter.com/vetlog_care"
-            ><i class="fa fa-2x fa-twitter"></i
-          ></a>
-          <a href="https://www.instagram.com/vetlog_care"
-            ><i class="fa fa-2x fa-instagram"></i
-          ></a>
-          <a href="https://tiktok.com/@vetlog_care"
-            ><svg
-              style="margin: 0px 15px"
-              fill="#ffffff"
-              width="22px"
-              height="22px"
-              viewBox="0 0 32 32"
-              version="1.1"
-              xmlns="http://www.w3.org/2000/svg"
-              stroke="#ffffff"
-            >
-              <g id="SVGRepo_bgCarrier" stroke-width="0"></g>
-              <g
-                id="SVGRepo_tracerCarrier"
-                stroke-linecap="round"
-                stroke-linejoin="round"
-              ></g>
-              <g id="SVGRepo_iconCarrier">
-                <title>tiktok</title>
-                <path
-                  d="M16.656 1.029c1.637-0.025 3.262-0.012 4.886-0.025 0.054 2.031 0.878 3.859 2.189 5.213l-0.002-0.002c1.411 1.271 3.247 2.095 5.271 2.235l0.028 0.002v5.036c-1.912-0.048-3.71-0.489-5.331-1.247l0.082 0.034c-0.784-0.377-1.447-0.764-2.077-1.196l0.052 0.034c-0.012 3.649 0.012 7.298-0.025 10.934-0.103 1.853-0.719 3.543-1.707 4.954l0.020-0.031c-1.652 2.366-4.328 3.919-7.371 4.011l-0.014 0c-0.123 0.006-0.268 0.009-0.414 0.009-1.73 0-3.347-0.482-4.725-1.319l0.040 0.023c-2.508-1.509-4.238-4.091-4.558-7.094l-0.004-0.041c-0.025-0.625-0.037-1.25-0.012-1.862 0.49-4.779 4.494-8.476 9.361-8.476 0.547 0 1.083 0.047 1.604 0.136l-0.056-0.008c0.025 1.849-0.050 3.699-0.050 5.548-0.423-0.153-0.911-0.242-1.42-0.242-1.868 0-3.457 1.194-4.045 2.861l-0.009 0.030c-0.133 0.427-0.21 0.918-0.21 1.426 0 0.206 0.013 0.41 0.037 0.61l-0.002-0.024c0.332 2.046 2.086 3.59 4.201 3.59 0.061 0 0.121-0.001 0.181-0.004l-0.009 0c1.463-0.044 2.733-0.831 3.451-1.994l0.010-0.018c0.267-0.372 0.45-0.822 0.511-1.311l0.001-0.014c0.125-2.237 0.075-4.461 0.087-6.698 0.012-5.036-0.012-10.060 0.025-15.083z"
-                ></path>
-              </g></svg
-          ></a>
-        </div>
-      </div>
-      <div class="row">
-        <div class="col-md-12 col-sm-12 text-center">
-          <a th:href="#{app.mailto}"
-            ><p style="font-size: 18px" th:text="#{app.contact.us}"
-          /></a>
-          <br /><br />
-          <p>© Copyright 2025, Vetlog.</p>
-          <a th:href="#{home.footer.link}"
-            ><p th:text="#{home.footer.name}"
-          /></a>
-        </div>
+  <div class="container">
+    <p></p>
+    <div class="row">
+      <div class="col-md-12 col-sm-12 text-center">
+        <a th:href="@{/}"><i th:text="#{home.name}"/></a> |
+        <a th:href="@{/pet/list}"><i th:text="#{home.list.name}"/></a> |
+        <a th:href="@{/pet/create}"><i th:text="#{home.register.name}"/></a> |
+        <a th:href="@{/pet/giveForAdoption}"><i th:text="#{adoption.name}"/></a> |
+        <a th:href="@{/privacy/show}"><i th:text="#{privacy.title}"/></a>
       </div>
     </div>
+    <div class="row margin-top">
+      <div class="col-md-12 col-sm-12 text-center">
+        <a href="https://twitter.com/vetlog_care"><i class="fa fa-2x fa-twitter"></i></a>
+        <a href="https://www.instagram.com/vetlog_care"><i class="fa fa-2x fa-instagram"></i></a>
+        <a href="https://tiktok.com/@vetlog_care"><svg style="margin: 0px 15px" fill="#ffffff" width="22px" height="22px" viewBox="0 0 32 32" version="1.1" xmlns="http://www.w3.org/2000/svg" stroke="#ffffff"><g id="SVGRepo_bgCarrier" stroke-width="0"></g><g id="SVGRepo_tracerCarrier" stroke-linecap="round" stroke-linejoin="round"></g><g id="SVGRepo_iconCarrier"> <title>tiktok</title> <path d="M16.656 1.029c1.637-0.025 3.262-0.012 4.886-0.025 0.054 2.031 0.878 3.859 2.189 5.213l-0.002-0.002c1.411 1.271 3.247 2.095 5.271 2.235l0.028 0.002v5.036c-1.912-0.048-3.71-0.489-5.331-1.247l0.082 0.034c-0.784-0.377-1.447-0.764-2.077-1.196l0.052 0.034c-0.012 3.649 0.012 7.298-0.025 10.934-0.103 1.853-0.719 3.543-1.707 4.954l0.020-0.031c-1.652 2.366-4.328 3.919-7.371 4.011l-0.014 0c-0.123 0.006-0.268 0.009-0.414 0.009-1.73 0-3.347-0.482-4.725-1.319l0.040 0.023c-2.508-1.509-4.238-4.091-4.558-7.094l-0.004-0.041c-0.025-0.625-0.037-1.25-0.012-1.862 0.49-4.779 4.494-8.476 9.361-8.476 0.547 0 1.083 0.047 1.604 0.136l-0.056-0.008c0.025 1.849-0.050 3.699-0.050 5.548-0.423-0.153-0.911-0.242-1.42-0.242-1.868 0-3.457 1.194-4.045 2.861l-0.009 0.030c-0.133 0.427-0.21 0.918-0.21 1.426 0 0.206 0.013 0.41 0.037 0.61l-0.002-0.024c0.332 2.046 2.086 3.59 4.201 3.59 0.061 0 0.121-0.001 0.181-0.004l-0.009 0c1.463-0.044 2.733-0.831 3.451-1.994l0.010-0.018c0.267-0.372 0.45-0.822 0.511-1.311l0.001-0.014c0.125-2.237 0.075-4.461 0.087-6.698 0.012-5.036-0.012-10.060 0.025-15.083z"></path> </g></svg></a>
+      </div>
+    </div>
+    <div class="row">
+      <div class="col-md-12 col-sm-12 text-center">
+        <a th:href="#{app.mailto}"><p style="font-size:18px" th:text="#{app.contact.us}"/></a>
+        <br/><br/>
+        <p>© Copyright 2025, Vetlog.</p>
+        <a th:href="#{home.footer.link}"><p th:text="#{home.footer.name}"/></a>
+      </div>
+    </div>
+  </div>
   </footer>
 </html>

--- a/src/main/resources/templates/fragments/footer.html
+++ b/src/main/resources/templates/fragments/footer.html
@@ -1,31 +1,66 @@
 <html>
   <footer>
-  <div class="container">
-    <p></p>
-    <div class="row">
-      <div class="col-md-12 col-sm-12 text-center">
-        <a th:href="@{/}"><i th:text="#{home.name}"/></a> |
-        <a th:href="@{/pet/list}"><i th:text="#{home.list.name}"/></a> |
-        <a th:href="@{/pet/create}"><i th:text="#{home.register.name}"/></a> |
-        <a th:href="@{/pet/giveForAdoption}"><i th:text="#{adoption.name}"/></a> |
-        <a th:href="@{/privacy/show}"><i th:text="#{privacy.title}"/></a>
+    <div class="container">
+      <p></p>
+      <div class="row">
+        <div class="col-md-12 col-sm-12 text-center">
+          <a th:href="@{/}"><i th:text="#{home.name}" /></a> |
+          <a th:href="@{/pet/list}"><i th:text="#{home.list.name}" /></a> |
+          <a th:href="@{/pet/create}"><i th:text="#{home.register.name}" /></a>
+          |
+          <a th:href="@{/pet/giveForAdoption}"
+            ><i th:text="#{adoption.name}"
+          /></a>
+          |
+          <a th:href="@{/privacy/show}"><i th:text="#{privacy.title}" /></a>
+        </div>
+      </div>
+      <div class="row margin-top">
+        <div class="col-md-12 col-sm-12 text-center">
+          <a href="https://twitter.com/vetlog_care"
+            ><i class="fa fa-2x fa-twitter"></i
+          ></a>
+          <a href="https://www.instagram.com/vetlog_care"
+            ><i class="fa fa-2x fa-instagram"></i
+          ></a>
+          <a href="https://tiktok.com/@vetlog_care"
+            ><svg
+              style="margin: 0px 15px"
+              fill="#ffffff"
+              width="22px"
+              height="22px"
+              viewBox="0 0 32 32"
+              version="1.1"
+              xmlns="http://www.w3.org/2000/svg"
+              stroke="#ffffff"
+            >
+              <g id="SVGRepo_bgCarrier" stroke-width="0"></g>
+              <g
+                id="SVGRepo_tracerCarrier"
+                stroke-linecap="round"
+                stroke-linejoin="round"
+              ></g>
+              <g id="SVGRepo_iconCarrier">
+                <title>tiktok</title>
+                <path
+                  d="M16.656 1.029c1.637-0.025 3.262-0.012 4.886-0.025 0.054 2.031 0.878 3.859 2.189 5.213l-0.002-0.002c1.411 1.271 3.247 2.095 5.271 2.235l0.028 0.002v5.036c-1.912-0.048-3.71-0.489-5.331-1.247l0.082 0.034c-0.784-0.377-1.447-0.764-2.077-1.196l0.052 0.034c-0.012 3.649 0.012 7.298-0.025 10.934-0.103 1.853-0.719 3.543-1.707 4.954l0.020-0.031c-1.652 2.366-4.328 3.919-7.371 4.011l-0.014 0c-0.123 0.006-0.268 0.009-0.414 0.009-1.73 0-3.347-0.482-4.725-1.319l0.040 0.023c-2.508-1.509-4.238-4.091-4.558-7.094l-0.004-0.041c-0.025-0.625-0.037-1.25-0.012-1.862 0.49-4.779 4.494-8.476 9.361-8.476 0.547 0 1.083 0.047 1.604 0.136l-0.056-0.008c0.025 1.849-0.050 3.699-0.050 5.548-0.423-0.153-0.911-0.242-1.42-0.242-1.868 0-3.457 1.194-4.045 2.861l-0.009 0.030c-0.133 0.427-0.21 0.918-0.21 1.426 0 0.206 0.013 0.41 0.037 0.61l-0.002-0.024c0.332 2.046 2.086 3.59 4.201 3.59 0.061 0 0.121-0.001 0.181-0.004l-0.009 0c1.463-0.044 2.733-0.831 3.451-1.994l0.010-0.018c0.267-0.372 0.45-0.822 0.511-1.311l0.001-0.014c0.125-2.237 0.075-4.461 0.087-6.698 0.012-5.036-0.012-10.060 0.025-15.083z"
+                ></path>
+              </g></svg
+          ></a>
+        </div>
+      </div>
+      <div class="row">
+        <div class="col-md-12 col-sm-12 text-center">
+          <a th:href="#{app.mailto}"
+            ><p style="font-size: 18px" th:text="#{app.contact.us}"
+          /></a>
+          <br /><br />
+          <p>© Copyright 2025, Vetlog.</p>
+          <a th:href="#{home.footer.link}"
+            ><p th:text="#{home.footer.name}"
+          /></a>
+        </div>
       </div>
     </div>
-    <div class="row margin-top">
-      <div class="col-md-12 col-sm-12 text-center">
-        <a href="https://twitter.com/vetlog_care"><i class="fa fa-2x fa-twitter"></i></a>
-        <a href="https://www.instagram.com/vetlog_care"><i class="fa fa-2x fa-instagram"></i></a>
-        <a href="https://tiktok.com/@vetlog_care"><svg style="margin: 0px 15px" fill="#ffffff" width="22px" height="22px" viewBox="0 0 32 32" version="1.1" xmlns="http://www.w3.org/2000/svg" stroke="#ffffff"><g id="SVGRepo_bgCarrier" stroke-width="0"></g><g id="SVGRepo_tracerCarrier" stroke-linecap="round" stroke-linejoin="round"></g><g id="SVGRepo_iconCarrier"> <title>tiktok</title> <path d="M16.656 1.029c1.637-0.025 3.262-0.012 4.886-0.025 0.054 2.031 0.878 3.859 2.189 5.213l-0.002-0.002c1.411 1.271 3.247 2.095 5.271 2.235l0.028 0.002v5.036c-1.912-0.048-3.71-0.489-5.331-1.247l0.082 0.034c-0.784-0.377-1.447-0.764-2.077-1.196l0.052 0.034c-0.012 3.649 0.012 7.298-0.025 10.934-0.103 1.853-0.719 3.543-1.707 4.954l0.020-0.031c-1.652 2.366-4.328 3.919-7.371 4.011l-0.014 0c-0.123 0.006-0.268 0.009-0.414 0.009-1.73 0-3.347-0.482-4.725-1.319l0.040 0.023c-2.508-1.509-4.238-4.091-4.558-7.094l-0.004-0.041c-0.025-0.625-0.037-1.25-0.012-1.862 0.49-4.779 4.494-8.476 9.361-8.476 0.547 0 1.083 0.047 1.604 0.136l-0.056-0.008c0.025 1.849-0.050 3.699-0.050 5.548-0.423-0.153-0.911-0.242-1.42-0.242-1.868 0-3.457 1.194-4.045 2.861l-0.009 0.030c-0.133 0.427-0.21 0.918-0.21 1.426 0 0.206 0.013 0.41 0.037 0.61l-0.002-0.024c0.332 2.046 2.086 3.59 4.201 3.59 0.061 0 0.121-0.001 0.181-0.004l-0.009 0c1.463-0.044 2.733-0.831 3.451-1.994l0.010-0.018c0.267-0.372 0.45-0.822 0.511-1.311l0.001-0.014c0.125-2.237 0.075-4.461 0.087-6.698 0.012-5.036-0.012-10.060 0.025-15.083z"></path> </g></svg></a>
-      </div>
-    </div>
-    <div class="row">
-      <div class="col-md-12 col-sm-12 text-center">
-        <a th:href="#{app.mailto}"><p style="font-size:18px" th:text="#{app.contact.us}"/></a>
-        <br/><br/>
-        <p>© Copyright 2025, Vetlog.</p>
-        <a th:href="#{home.footer.link}"><p th:text="#{home.footer.name}"/></a>
-      </div>
-    </div>
-  </div>
   </footer>
 </html>


### PR DESCRIPTION
Corrected the Spanish footer label by removing the extra "Us" in messages_es.properties. Now displays "Contactáctanos: [vetlog@josdem.io](mailto:vetlog@josdem.io)" correctly.