### PR TITLE
Remove extra "Assertions" keyword in the service tests

### DIFF
--- a/src/test/java/com/josdem/vetlog/service/AdoptionServiceTest.kt
+++ b/src/test/java/com/josdem/vetlog/service/AdoptionServiceTest.kt
@@ -16,12 +16,13 @@
 
 package com.josdem.vetlog.service
 
+import org.junit.jupiter.api.Assertions.assertEquals
+
 import com.josdem.vetlog.command.AdoptionCommand
 import com.josdem.vetlog.enums.PetStatus
 import com.josdem.vetlog.model.Pet
 import com.josdem.vetlog.repository.PetRepository
 import com.josdem.vetlog.service.impl.AdoptionServiceImpl
-import org.junit.jupiter.api.Assertions
 import org.junit.jupiter.api.BeforeEach
 import org.mockito.Mock
 import org.mockito.MockitoAnnotations
@@ -60,9 +61,9 @@ internal class AdoptionServiceTest {
         val result = service.save(adoptionCommand)
 
         verify(petRepository).save(pet)
-        Assertions.assertEquals(PetStatus.IN_ADOPTION, pet.status)
-        Assertions.assertEquals(pet, result.pet)
-        Assertions.assertEquals("description", result.description)
+        assertEquals(PetStatus.IN_ADOPTION, pet.status)
+        assertEquals(pet, result.pet)
+        assertEquals("description", result.description)
     }
 
     private fun getPet(): Pet {

--- a/src/test/java/com/josdem/vetlog/service/BreedServiceTest.kt
+++ b/src/test/java/com/josdem/vetlog/service/BreedServiceTest.kt
@@ -16,14 +16,13 @@
 
 package com.josdem.vetlog.service
 
+import org.junit.jupiter.api.Assertions.assertTrue
+
 import com.josdem.vetlog.model.Breed
 import com.josdem.vetlog.repository.BreedRepository
 import com.josdem.vetlog.service.impl.BreedServiceImpl
 import com.josdem.vetlog.enums.PetType
-import org.junit.jupiter.api.Assertions
 import org.junit.jupiter.api.BeforeEach
-import org.junit.jupiter.api.DisplayName
-import org.junit.jupiter.api.TestInfo
 import org.mockito.Mock
 import org.mockito.MockitoAnnotations
 import org.mockito.kotlin.whenever
@@ -57,7 +56,7 @@ internal class BreedServiceTest {
 
         val breeds = service.getBreedsByType(PetType.DOG)
 
-        Assertions.assertTrue(breeds.isNotEmpty(), "should have a breed")
+        assertTrue(breeds.isNotEmpty(), "should have a breed")
         verify(breedRepository).findByType(PetType.DOG)
     }
 }

--- a/src/test/java/com/josdem/vetlog/service/LocaleServiceTest.kt
+++ b/src/test/java/com/josdem/vetlog/service/LocaleServiceTest.kt
@@ -15,10 +15,11 @@
 */
 package com.josdem.vetlog.service
 
+import org.junit.jupiter.api.Assertions.assertEquals
+
 import com.josdem.vetlog.helper.LocaleResolver
 import jakarta.servlet.http.HttpServletRequest
 import com.josdem.vetlog.service.impl.LocaleServiceImpl
-import org.junit.jupiter.api.Assertions
 import org.junit.jupiter.api.BeforeEach
 import org.mockito.Mock
 import org.mockito.Mockito.mock
@@ -59,7 +60,7 @@ internal class LocaleServiceTest {
         whenever(messageSource.getMessage(code, null, localeResolver.resolveLocale(request)))
             .thenReturn("message")
 
-        Assertions.assertEquals("message", service.getMessage(code, request))
+        assertEquals("message", service.getMessage(code, request))
     }
 
     @Test
@@ -68,7 +69,7 @@ internal class LocaleServiceTest {
 
         whenever(messageSource.getMessage(code, null, Locale.of("en"))).thenReturn("message")
 
-        Assertions.assertEquals("message", service.getMessage(code))
+        assertEquals("message", service.getMessage(code))
     }
 }
 

--- a/src/test/java/com/josdem/vetlog/service/PetLogServiceTest.kt
+++ b/src/test/java/com/josdem/vetlog/service/PetLogServiceTest.kt
@@ -15,6 +15,8 @@
 */
 package com.josdem.vetlog.service
 
+import org.junit.jupiter.api.Assertions.assertEquals
+
 import com.josdem.vetlog.binder.PetLogBinder
 import com.josdem.vetlog.command.PetLogCommand
 import com.josdem.vetlog.exception.BusinessException
@@ -23,7 +25,6 @@ import com.josdem.vetlog.model.PetLog
 import com.josdem.vetlog.repository.PetLogRepository
 import com.josdem.vetlog.repository.PetRepository
 import com.josdem.vetlog.service.impl.PetLogServiceImpl
-import org.junit.jupiter.api.Assertions
 import org.junit.jupiter.api.BeforeEach
 import org.junit.jupiter.api.assertThrows
 import org.mockito.Mock
@@ -99,7 +100,7 @@ internal class PetLogServiceTest {
 
         val result = service.getPetLogsByPet(pet)
 
-        Assertions.assertEquals(listOf(petLog), result)
+        assertEquals(listOf(petLog), result)
     }
 
     private fun getPetLog(): PetLog {

--- a/src/test/java/com/josdem/vetlog/service/PetServiceTest.kt
+++ b/src/test/java/com/josdem/vetlog/service/PetServiceTest.kt
@@ -15,6 +15,11 @@
 */
 package com.josdem.vetlog.service
 
+import org.junit.jupiter.api.Assertions.assertDoesNotThrow
+import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.Assertions.assertThrows
+import org.junit.jupiter.api.Assertions.assertTrue
+
 import com.josdem.vetlog.binder.PetBinder
 import com.josdem.vetlog.command.Command
 import com.josdem.vetlog.command.PetCommand
@@ -27,7 +32,6 @@ import com.josdem.vetlog.repository.AdoptionRepository
 import com.josdem.vetlog.repository.PetRepository
 import com.josdem.vetlog.repository.UserRepository
 import com.josdem.vetlog.service.impl.PetServiceImpl
-import org.junit.jupiter.api.Assertions
 import org.junit.jupiter.api.BeforeEach
 import org.junit.jupiter.api.Test
 import org.mockito.Mock
@@ -120,8 +124,8 @@ internal class PetServiceTest {
         whenever(userRepository.findById(3L)).thenReturn(Optional.of(adopter!!))
 
         service.update(command)
-        Assertions.assertEquals(user, pet!!.user)
-        Assertions.assertEquals(adopter, pet!!.adopter)
+        assertEquals(user, pet!!.user)
+        assertEquals(adopter, pet!!.adopter)
         verify(petImageService).attachFile(command)
         verify(petRepository).save(any())
         verify(command).images = any()
@@ -141,7 +145,7 @@ internal class PetServiceTest {
         whenever(command.adopter).thenReturn(3L)
         whenever(userRepository.findById(1L)).thenReturn(Optional.empty())
 
-        Assertions.assertThrows(BusinessException::class.java) {
+        assertThrows(BusinessException::class.java) {
             service.update(command)
         }
     }
@@ -152,7 +156,7 @@ internal class PetServiceTest {
         val command: PetCommand = mock()
         whenever(petRepository.findById(2L)).thenReturn(Optional.of(pet!!))
 
-        Assertions.assertThrows(BusinessException::class.java) {
+        assertThrows(BusinessException::class.java) {
             service.update(command)
         }
     }
@@ -161,7 +165,7 @@ internal class PetServiceTest {
     fun `Not update due to pet not found`() {
         log.info("Running test: Not update due to pet not found")
         val command: PetCommand = mock()
-        Assertions.assertThrows(BusinessException::class.java) {
+        assertThrows(BusinessException::class.java) {
             service.update(command)
         }
     }
@@ -170,7 +174,7 @@ internal class PetServiceTest {
     fun `Getting pet by uuid`() {
         log.info("Running test: Getting pet by uuid")
         whenever(petRepository.findByUuid("uuid")).thenReturn(Optional.of(pet!!))
-        Assertions.assertEquals(pet, service.getPetByUuid("uuid"))
+        assertEquals(pet, service.getPetByUuid("uuid"))
     }
 
     @Test
@@ -178,13 +182,13 @@ internal class PetServiceTest {
         log.info("Running test: Getting pet by id")
         val optionalPet = Optional.of(pet!!)
         whenever(petRepository.findById(1L)).thenReturn(optionalPet)
-        Assertions.assertEquals(pet, service.getPetById(1L))
+        assertEquals(pet, service.getPetById(1L))
     }
 
     @Test
     fun `Pet by id not found`() {
         log.info("Running test: Pet by id not found")
-        Assertions.assertThrows(BusinessException::class.java) {
+        assertThrows(BusinessException::class.java) {
             service.getPetById(1L)
         }
     }
@@ -195,7 +199,7 @@ internal class PetServiceTest {
         whenever(petRepository.findAllByUser(user)).thenReturn(listOf(pet))
         whenever(petRepository.findAllByAdopter(user)).thenReturn(mutableListOf())
         whenever(petRepository.findAllByStatus(PetStatus.ADOPTED)).thenReturn(mutableListOf())
-        Assertions.assertEquals(1, service.getPetsByUser(user).size)
+        assertEquals(1, service.getPetsByUser(user).size)
     }
 
     @Test
@@ -205,7 +209,7 @@ internal class PetServiceTest {
         whenever(petRepository.findAllByUser(user)).thenReturn(pets)
         whenever(petRepository.findAllByAdopter(user)).thenReturn(mutableListOf())
         whenever(petRepository.findAllByStatus(PetStatus.ADOPTED)).thenReturn(pets)
-        Assertions.assertTrue(service.getPetsByUser(user).isEmpty())
+        assertTrue(service.getPetsByUser(user).isEmpty())
     }
 
     @Test
@@ -214,14 +218,14 @@ internal class PetServiceTest {
         whenever(petRepository.findAllByUser(user)).thenReturn(mutableListOf())
         whenever(petRepository.findAllByAdopter(user)).thenReturn(listOf(pet))
         whenever(petRepository.findAllByStatus(PetStatus.ADOPTED)).thenReturn(mutableListOf())
-        Assertions.assertEquals(1, service.getPetsByUser(user).size)
+        assertEquals(1, service.getPetsByUser(user).size)
     }
 
     @Test
     fun `Getting pet by status`() {
         log.info("Running test: Getting pet by status")
         whenever(petRepository.findAllByStatus(PetStatus.OWNED)).thenReturn(pets)
-        Assertions.assertEquals(pets, service.getPetsByStatus(PetStatus.OWNED))
+        assertEquals(pets, service.getPetsByStatus(PetStatus.OWNED))
     }
 
     @Test
@@ -237,14 +241,14 @@ internal class PetServiceTest {
         whenever(adoptionRepository.findByPet(pet)).thenReturn(optional)
 
         service.getPetsAdoption(pets)
-        Assertions.assertEquals("It is cute!", pets[0]!!.adoption.description)
+        assertEquals("It is cute!", pets[0]!!.adoption.description)
     }
 
     @Test
     fun `Deleting a pet`() {
         log.info("Running test: Deleting a pet")
         whenever(petRepository.findById(1L)).thenReturn(Optional.of(pet!!))
-        Assertions.assertDoesNotThrow {
+        assertDoesNotThrow {
             service.deletePetById(1L)
         }
         verify(vaccinationService).deleteVaccinesByPet(pet)
@@ -253,7 +257,7 @@ internal class PetServiceTest {
     fun `Not deleting a pet due to not found`() {
         log.info("Running test: Not deleting a pet due to not found")
         whenever(petRepository.findById(1L)).thenReturn(Optional.empty())
-        Assertions.assertThrows(BusinessException::class.java) {
+        assertThrows(BusinessException::class.java) {
             service.deletePetById(1L)
         }
     }
@@ -266,7 +270,7 @@ internal class PetServiceTest {
         }
         whenever(petRepository.findById(1L)).thenReturn(Optional.of(petInAdoption))
 
-        Assertions.assertThrows(BusinessException::class.java) {
+        assertThrows(BusinessException::class.java) {
             service.deletePetById(1L)
         }
     }

--- a/src/test/java/com/josdem/vetlog/service/RecoveryServiceTest.kt
+++ b/src/test/java/com/josdem/vetlog/service/RecoveryServiceTest.kt
@@ -15,6 +15,11 @@
 */
 package com.josdem.vetlog.service
 
+import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.Assertions.assertFalse
+import org.junit.jupiter.api.Assertions.assertThrows
+import org.junit.jupiter.api.Assertions.assertTrue
+
 import com.josdem.vetlog.command.ChangePasswordCommand
 import com.josdem.vetlog.command.MessageCommand
 import com.josdem.vetlog.exception.UserNotFoundException
@@ -24,7 +29,6 @@ import com.josdem.vetlog.model.User
 import com.josdem.vetlog.repository.RegistrationCodeRepository
 import com.josdem.vetlog.repository.UserRepository
 import com.josdem.vetlog.service.impl.RecoveryServiceImpl
-import org.junit.jupiter.api.Assertions
 import org.junit.jupiter.api.BeforeEach
 import org.mockito.Mock
 import org.mockito.MockitoAnnotations
@@ -75,21 +79,21 @@ internal class RecoveryServiceTest {
 
         service.confirmAccountForToken(TOKEN)
 
-        Assertions.assertTrue(user.isEnabled)
+        assertTrue(user.isEnabled)
         verify(userRepository).save(user)
     }
 
     @Test
     fun `Not sending activation account token due to token not existing`() {
         log.info("Running test: Not sending activation account token due to token not existing")
-        Assertions.assertThrows(VetlogException::class.java) { service.confirmAccountForToken(TOKEN) }
+        assertThrows(VetlogException::class.java) { service.confirmAccountForToken(TOKEN) }
     }
 
     @Test
     fun `Not sending activation account token due to user not found`() {
         log.info("Running test: Not sending activation account token due to user not found")
         whenever(registrationService.findEmailByToken(TOKEN)).thenReturn(Optional.of(EMAIL))
-        Assertions.assertThrows(UserNotFoundException::class.java) { service.confirmAccountForToken(TOKEN) }
+        assertThrows(UserNotFoundException::class.java) { service.confirmAccountForToken(TOKEN) }
     }
 
     @Test
@@ -107,7 +111,7 @@ internal class RecoveryServiceTest {
     @Test
     fun `Not sending change password token due to user not found`() {
         log.info("Running test: Not sending change password token due to user not found")
-        Assertions.assertThrows(UserNotFoundException::class.java) { service.generateRegistrationCodeForEmail(EMAIL) }
+        assertThrows(UserNotFoundException::class.java) { service.generateRegistrationCodeForEmail(EMAIL) }
     }
 
     @Test
@@ -115,20 +119,20 @@ internal class RecoveryServiceTest {
         log.info("Running test: Not sending change password token due to user not enabled")
         user.isEnabled = false
         whenever(userRepository.findByEmail(EMAIL)).thenReturn(Optional.of(user))
-        Assertions.assertThrows(VetlogException::class.java) { service.generateRegistrationCodeForEmail(EMAIL) }
+        assertThrows(VetlogException::class.java) { service.generateRegistrationCodeForEmail(EMAIL) }
     }
 
     @Test
     fun `Validating a token`() {
         log.info("Running test: Validating a token")
         whenever(repository.findByToken(TOKEN)).thenReturn(Optional.of(RegistrationCode()))
-        Assertions.assertTrue(service.validateToken(TOKEN))
+        assertTrue(service.validateToken(TOKEN))
     }
 
     @Test
     fun `Finding an invalid token`() {
         log.info("Running test: Finding an invalid token")
-        Assertions.assertFalse(service.validateToken(TOKEN))
+        assertFalse(service.validateToken(TOKEN))
     }
 
     @Test
@@ -143,7 +147,7 @@ internal class RecoveryServiceTest {
 
         service.changePassword(changePasswordCommand)
 
-        Assertions.assertEquals(60, user.password.length)
+        assertEquals(60, user.password.length)
         verify(userRepository).save(user)
     }
 }

--- a/src/test/java/com/josdem/vetlog/service/RegistrationServiceTest.kt
+++ b/src/test/java/com/josdem/vetlog/service/RegistrationServiceTest.kt
@@ -15,10 +15,11 @@
 */
 package com.josdem.vetlog.service
 
+import org.junit.jupiter.api.Assertions.assertEquals
+
 import com.josdem.vetlog.model.RegistrationCode
 import com.josdem.vetlog.repository.RegistrationCodeRepository
 import com.josdem.vetlog.service.impl.RegistrationServiceImpl
-import org.junit.jupiter.api.Assertions
 import org.junit.jupiter.api.BeforeEach
 import org.mockito.Mock
 import org.mockito.MockitoAnnotations
@@ -55,14 +56,14 @@ internal class RegistrationServiceTest {
         log.info("Running test: Getting user by token")
         val registrationCode = RegistrationCode().apply { email = EMAIL }
         whenever(repository.findByToken(TOKEN)).thenReturn(Optional.of(registrationCode))
-        Assertions.assertEquals(EMAIL, service.findEmailByToken(TOKEN).get())
+        assertEquals(EMAIL, service.findEmailByToken(TOKEN).get())
     }
 
     @Test
     fun `Generating token`() {
         log.info("Running test: Generating token")
         val token = service.generateToken(EMAIL)
-        Assertions.assertEquals(36, token.length)
+        assertEquals(36, token.length)
         verify(repository).save(any<RegistrationCode>())
     }
 }

--- a/src/test/java/com/josdem/vetlog/service/TelephoneServiceTest.kt
+++ b/src/test/java/com/josdem/vetlog/service/TelephoneServiceTest.kt
@@ -15,6 +15,8 @@
 */
 package com.josdem.vetlog.service
 
+import org.junit.jupiter.api.Assertions.assertEquals
+
 import com.josdem.vetlog.command.MessageCommand
 import com.josdem.vetlog.command.TelephoneCommand
 import com.josdem.vetlog.enums.PetStatus
@@ -23,7 +25,6 @@ import com.josdem.vetlog.model.User
 import com.josdem.vetlog.repository.PetRepository
 import com.josdem.vetlog.repository.UserRepository
 import com.josdem.vetlog.service.impl.TelephoneServiceImpl
-import org.junit.jupiter.api.Assertions
 import org.junit.jupiter.api.BeforeEach
 import org.mockito.Mock
 import org.mockito.MockitoAnnotations
@@ -78,8 +79,8 @@ internal class TelephoneServiceTest {
         verify(petRepository).save(pet)
         verify(userRepository).save(adopter)
         verify(restService).sendMessage(any<MessageCommand>())
-        Assertions.assertEquals(PetStatus.ADOPTED, pet.status)
-        Assertions.assertEquals(adopter, pet.adopter)
+        assertEquals(PetStatus.ADOPTED, pet.status)
+        assertEquals(adopter, pet.adopter)
     }
 
     private fun getPet(owner: User?, adopter: User?): Pet {

--- a/src/test/java/com/josdem/vetlog/service/UserDetailsServiceTest.kt
+++ b/src/test/java/com/josdem/vetlog/service/UserDetailsServiceTest.kt
@@ -15,12 +15,13 @@
 */
 package com.josdem.vetlog.service
 
+import org.junit.jupiter.api.Assertions.assertEquals
+
 import com.josdem.vetlog.enums.Role
 import com.josdem.vetlog.exception.BusinessException
 import com.josdem.vetlog.model.User
 import com.josdem.vetlog.repository.UserRepository
 import com.josdem.vetlog.service.impl.UserDetailsServiceImpl
-import org.junit.jupiter.api.Assertions
 import org.junit.jupiter.api.BeforeEach
 import org.junit.jupiter.api.assertThrows
 import org.mockito.Mock
@@ -61,9 +62,9 @@ internal class UserDetailsServiceTest {
 
         val result = service.loadUserByUsername(USERNAME)
 
-        Assertions.assertEquals(user.username, result.username)
-        Assertions.assertEquals(user.password, result.password)
-        Assertions.assertEquals(user.isEnabled, result.isEnabled)
+        assertEquals(user.username, result.username)
+        assertEquals(user.password, result.password)
+        assertEquals(user.isEnabled, result.isEnabled)
     }
 
     @Test

--- a/src/test/java/com/josdem/vetlog/service/VaccinationServiceTest.kt
+++ b/src/test/java/com/josdem/vetlog/service/VaccinationServiceTest.kt
@@ -15,6 +15,8 @@
 */
 package com.josdem.vetlog.service
 
+import org.junit.jupiter.api.Assertions.assertEquals
+
 import com.josdem.vetlog.enums.PetType
 import com.josdem.vetlog.enums.VaccinationStatus
 import com.josdem.vetlog.exception.BusinessException
@@ -26,7 +28,6 @@ import com.josdem.vetlog.service.impl.VaccinationServiceImpl
 import com.josdem.vetlog.strategy.vaccination.VaccinationStrategy
 import com.josdem.vetlog.strategy.vaccination.impl.CatVaccinationStrategy
 import com.josdem.vetlog.strategy.vaccination.impl.DogVaccinationStrategy
-import org.junit.jupiter.api.Assertions
 import org.junit.jupiter.api.BeforeEach
 import org.junit.jupiter.api.assertThrows
 import org.junit.jupiter.params.ParameterizedTest
@@ -107,7 +108,7 @@ internal class VaccinationServiceTest {
             )
         )
         val vaccinesInPendingStatus = vaccinationService.getVaccinesByStatus(pet, VaccinationStatus.PENDING)
-        Assertions.assertEquals(1, vaccinesInPendingStatus.size)
+        assertEquals(1, vaccinesInPendingStatus.size)
     }
 
     @Test


### PR DESCRIPTION
Remove extra "Assertions" keyword in the service tests. Remove from BreedServiceTest unused imports (org.junit.jupiter.api.TestInfo and org.junit.jupiter.api.DisplayName). All this 10 tests is passing.
Solution for issue #487 

![screenshot passing tests](https://github.com/user-attachments/assets/7ce425bc-5738-4267-803d-6771cfa71357)
