### PR TITLE
#548 adding google map html page

### DIFF
--- a/src/main/resources/templates/map/map.html
+++ b/src/main/resources/templates/map/map.html
@@ -1,0 +1,51 @@
+<!-- templates/map/map.html -->
+<!DOCTYPE html>
+<html lang="en" xmlns:th="http://www.thymeleaf.org">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>Vetlog Map View</title>
+    <link rel="stylesheet" href="/static/assets/servizi-dog-theme/css/style.css"> <!-- Adjust if needed -->
+    <style>
+        .map-container {
+            position: relative;
+            width: 100%;
+            padding-bottom: 56.25%; /* 16:9 aspect ratio */
+            margin: 20px auto;
+            border-radius: 12px;
+            overflow: hidden;
+            box-shadow: 0 4px 8px rgba(0,0,0,0.1);
+            max-width: 1200px;
+        }
+        .map-container iframe {
+            position: absolute;
+            top: 0;
+            left: 0;
+            width: 100%;
+            height: 100%;
+            border: 0;
+        }
+    </style>
+</head>
+<body>
+
+    <!-- Include header fragment -->
+    <div th:replace="fragments/header :: header"></div>
+
+    <main>
+        <h1 style="text-align:center; margin-top: 20px;">Vetlog Location Map</h1>
+        <div class="map-container">
+            <iframe
+                src="https://www.google.com/maps/embed?pb=!1m18!1m12!1m3!1d3010.017688960258!2d29.03037248997648!3d41.02486894453692!2m3!1f0!2f0!3f0!3m2!1i1024!2i768!4f13.1!3m3!1m2!1s0x14cab7be76b93d45%3A0x81ea144710334607!2zNy8yNCBBQ8SwTCBWRVRMT0cgVkVURVLEsE5FUiBLTMSwTsSwxJ7EsCDDnFNLw5xEQVI!5e0!3m2!1sen!2sin!4v1746204328790!5m2!1sen!2sin"
+                allowfullscreen=""
+                loading="lazy"
+                referrerpolicy="no-referrer-when-downgrade">
+            </iframe>
+        </div>
+    </main>
+
+    <!-- Include footer fragment -->
+    <div th:replace="fragments/footer :: footer"></div>
+
+</body>
+</html>


### PR DESCRIPTION
Fix: #548 
```html
<!--
In templates/map/map.html:
- Included header (from fragments/) with CSS from static/assets/servizi-dog-theme/style.css
- Embedded Google Maps iframe (Vetlog's link) with its own inline styles
- Included footer (from fragments/) with the same CSS from static/assets/servizi-dog-theme/style.css
-->
```
Note: The style.css used for the header and footer does not affect the content inside the Google Maps iframe (I HOPE SO), as iframe content is sandboxed. Only the container around the iframe can be styled externally.
