### PR TITLE
Deleted dewormed and vaccinated from pet forms

### DIFF
--- a/src/main/resources/templates/adoption/descriptionForAdoption.html
+++ b/src/main/resources/templates/adoption/descriptionForAdoption.html
@@ -20,9 +20,7 @@
                     <h3 th:text="${pet.name}"></h3>
                     <p th:text="${@dateFormatter.formatToDate(pet.birthDate, #locale)}"/>
                     <p th:text="${pet.breed.name}"/>
-                    <p th:text="${pet.dewormed}? #{pet.dewormed} : #{pet.not.dewormed}"/>
                     <p th:text="${pet.sterilized}? #{pet.sterilized} : #{pet.not.sterilized}"/>
-                    <p th:text="${pet.vaccinated}? #{pet.vaccinated} : #{pet.not.vaccinated}"/>
                     <br/>
                     <form id="description" th:action="@{/adoption/save}" th:object="${adoptionCommand}" method="post"
                           class="form-horizontal">

--- a/src/main/resources/templates/pet/create.html
+++ b/src/main/resources/templates/pet/create.html
@@ -38,20 +38,10 @@
                             <input th:data-testid="birthDate" type="date" id="birthDate" name="birthDate" min="${#dates.format(#dates.createNow(), 'yyyy-MM-dd')}">
                             <label th:if="${#fields.hasErrors('birthDate')}" th:errors="*{birthDate}"></label>
                             <br/>
-                            <label for="dewormed"><h4 th:text="#{pet.dewormed}"/></label>
-                            <input type="checkbox" name='dewormed' th:field="*{dewormed}" class="form-control"
-                                   placeholder="dewormed" id='dewormed'/>
-                            <label th:if="${#fields.hasErrors('dewormed')}" th:errors="*{dewormed}"></label>
-                            <br/>
                             <label for="sterilized"><h4 th:text="#{pet.sterilized}"/></label>
                             <input type="checkbox" name='sterilized' th:field="*{sterilized}" class="form-control"
                                    placeholder="sterilized" id='sterilized'/>
                             <label th:if="${#fields.hasErrors('sterilized')}" th:errors="*{sterilized}"></label>
-                            <br/>
-                            <label for="vaccinated"><h4 th:text="#{pet.vaccinated}"/></label>
-                            <input type="checkbox" name='vaccinated' th:field="*{vaccinated}" class="form-control"
-                                   placeholder="vaccinated" id='vaccinated'/>
-                            <label th:if="${#fields.hasErrors('vaccinated')}" th:errors="*{vaccinated}"></label>
                             <br/>
                             <br/>
                             <label for="type"><h4 th:text="#{pet.type}"/></label>

--- a/src/main/resources/templates/pet/edit.html
+++ b/src/main/resources/templates/pet/edit.html
@@ -67,20 +67,10 @@
                             <input th:data-testid="birthDate" th:type="date" id="birthDate" th:name="birthDate" th:field="*{birthDate}" class="form-control">
                             <label th:if="${#fields.hasErrors('birthDate')}" th:errors="*{birthDate}"></label>
                             <br/>
-                            <label for="dewormed"><h4 th:text="#{pet.dewormed}"/></label>
-                            <input type="checkbox" name='dewormed' th:data-testid="petDewormed" th:field="*{dewormed}" class="form-control"
-                                   placeholder="dewormed" id='dewormed'/>
-                            <label th:if="${#fields.hasErrors('dewormed')}" th:errors="*{dewormed}"></label>
-                            <br/>
                             <label for="sterilized"><h4 th:text="#{pet.sterilized}"/></label>
                             <input type="checkbox" name='sterilized' th:data-testid="petSterilized" th:field="*{sterilized}" class="form-control"
                                    placeholder="sterilized" id='sterilized'/>
                             <label th:if="${#fields.hasErrors('sterilized')}" th:errors="*{sterilized}"></label>
-                            <br/>
-                            <label for="vaccinated"><h4 th:text="#{pet.vaccinated}"/></label>
-                            <input type="checkbox" name='vaccinated' th:data-testid="petVaccinated" th:field="*{vaccinated}" class="form-control"
-                                   placeholder="vaccinated" id='vaccinated'/>
-                            <label th:if="${#fields.hasErrors('vaccinated')}" th:errors="*{vaccinated}"></label>
                             <br/>
                             <table th:if="${!petCommand.vaccines.isEmpty()}">
                                 <thead>

--- a/src/main/resources/templates/pet/giveForAdoption.html
+++ b/src/main/resources/templates/pet/giveForAdoption.html
@@ -28,9 +28,7 @@
                         <ul>
                             <li th:text="${@dateFormatter.formatToDate(pet.birthDate, #locale)}"/>
                             <li th:text="${pet.breed.name}"/>
-                            <li th:text="${pet.dewormed}? #{pet.dewormed} : #{pet.not.dewormed}"/>
                             <li th:text="${pet.sterilized}? #{pet.sterilized} : #{pet.not.sterilized}"/>
-                            <li th:text="${pet.vaccinated}? #{pet.vaccinated} : #{pet.not.vaccinated}"/>
                         </ul>
                         </p>
                         <br/>

--- a/src/main/resources/templates/pet/list.html
+++ b/src/main/resources/templates/pet/list.html
@@ -79,9 +79,7 @@
                                 <ul>
                                     <li th:data-testid="petBirhdate" th:text="${@dateFormatter.formatToDate(pet.birthDate, #locale)}"/>
                                     <li th:data-testid="petBreed" th:text="${pet.breed.name}"/>
-                                    <li th:data-testid="petDewormed" th:text="${pet.dewormed}? #{pet.dewormed} : #{pet.not.dewormed}"/>
                                     <li th:data-testid="petSterilized" th:text="${pet.sterilized}? #{pet.sterilized} : #{pet.not.sterilized}"/>
-                                    <li th:data-testid="petVaccinated" th:text="${pet.vaccinated}? #{pet.vaccinated} : #{pet.not.vaccinated}"/>
                                 </ul>
                                 <br>
                                 <table th:if="${!pet.vaccines.isEmpty()}">

--- a/src/main/resources/templates/pet/listForAdoption.html
+++ b/src/main/resources/templates/pet/listForAdoption.html
@@ -64,9 +64,7 @@
                         <h3 th:data-testid="petName" th:text="${pet.name}"></h3>
                         <p th:data-testid="petBirhdate" th:text="${@dateFormatter.formatToDate(pet.birthDate, #locale)}"/>
                         <p th:data-testid="petBreed" th:text="${pet.breed.name}"/>
-                        <p th:data-testid="petDewormed" th:text="${pet.dewormed}? #{pet.dewormed} : #{pet.not.dewormed}"/>
                         <p th:data-testid="petSterilized" th:text="${pet.sterilized}? #{pet.sterilized} : #{pet.not.sterilized}"/>
-                        <p th:data-testid="petVaccinated" th:text="${pet.vaccinated}? #{pet.vaccinated} : #{pet.not.vaccinated}"/>
                         <p th:data-testid="petAdoptionDescription" th:text="${pet.adoption?.description}"/>
                         <br/>
                         <a th:href="@{/telephone/adopt(uuid=${pet.uuid})}" class="btn btn-success">

--- a/src/main/resources/templates/vet/list.html
+++ b/src/main/resources/templates/vet/list.html
@@ -75,9 +75,7 @@
                                 <ul>
                                     <li th:data-testid="petBirthdate" th:text="${@dateFormatter.formatToDate(pet.birthDate, #locale)}"/>
                                     <li th:data-testid="petBreed" th:text="${pet.breed.name}"/>
-                                    <li th:data-testid="petDewormed" th:text="${pet.dewormed}? #{pet.dewormed} : #{pet.not.dewormed}"/>
                                     <li th:data-testid="petSterilized" th:text="${pet.sterilized}? #{pet.sterilized} : #{pet.not.sterilized}"/>
-                                    <li th:data-testid="petVaccinated" th:text="${pet.vaccinated}? #{pet.vaccinated} : #{pet.not.vaccinated}"/>
                                 </ul>
                                 <br>
                                 <table th:if="${!pet.vaccines.isEmpty()}">


### PR DESCRIPTION
This PR address the [issue](https://github.com/josdem/vetlog-spring-boot/issues/616) and removes vaccinated and dewormed fields from the pet related view.

Removed vaccinated and dewormed fields from the following templates:

- pet/edit.html
- pet/create.html
- adoption/descriptionForAdoption.html
- pet/giveForAdoption.html
- pet/list.html
- pet/listForAdoption.html
- vet/list.html