### PR TITLE
fix: correct birthdate display after a pet edition

### DIFF
--- a/src/main/java/com/josdem/vetlog/controller/PetController.java
+++ b/src/main/java/com/josdem/vetlog/controller/PetController.java
@@ -22,6 +22,7 @@ import com.josdem.vetlog.enums.PetStatus;
 import com.josdem.vetlog.enums.PetType;
 import com.josdem.vetlog.enums.VaccinationStatus;
 import com.josdem.vetlog.model.Breed;
+import com.josdem.vetlog.model.Pet;
 import com.josdem.vetlog.model.User;
 import com.josdem.vetlog.service.BreedService;
 import com.josdem.vetlog.service.LocaleService;
@@ -115,7 +116,8 @@ public class PetController {
             modelAndView.addObject(PET_COMMAND, petCommand);
             return fillModelAndView(modelAndView);
         }
-        petService.update(petCommand);
+        Pet updatedPet = petService.update(petCommand);
+        petCommand = petBinder.bindPet(updatedPet);
         modelAndView.addObject(MESSAGE, localeService.getMessage("pet.updated", request));
         modelAndView.addObject(GCP_IMAGE_URL, gcpUrl + imageBucket + "/");
         modelAndView.addObject(PET_COMMAND, petCommand);


### PR DESCRIPTION
### PR Description: Fix birthdate not populated after pet update (#618)

#### Summary
This PR fixes #618 an issue where the birthdate field was not being populated after updating a pet's information.

#### Root Cause
Previously, the birthdate value was being set from the request information, which includes a hour part. The frontend expects the value in the `yyyy-mm-dd` format, causing the birthdate field to appear empty with warning in browser console.

#### Fix
- Changed the source of the birthdate field to use the pet object returned from service and then binding to command (which preserves the original `yyyy-mm-dd` format).
- This ensures the birthdate remains correctly formatted and visible in the edit form after update.

#### How to Test
1. Login as a user with at least one registered pet.
2. Go to the "List" view from the main menu.
3. Edit any pet's details.
4. Save the changes.
5. Confirm that the birthdate is still populated correctly.