### PR TITLE
Fix navbar overflow issue in Firefox & spanish language with long menu labels

### DIFF
--- a/src/main/resources/static/assets/servizi-dog-theme/css/style.css
+++ b/src/main/resources/static/assets/servizi-dog-theme/css/style.css
@@ -292,7 +292,7 @@ section.section-darker img {
 	font-size: 15px;
 	font-weight: 300;
 	text-transform: uppercase;
-	padding: 40px;
+	padding: 40px 35px;
 	color: #555 !important;
 	transition: all 0.3s;
 	-webkit-transition: all 0.3s;


### PR DESCRIPTION
Problem
When using Firefox with the Spanish language, the main navigation bar appears misaligned due to longer translated menu items. This causes layout issues that are not present in English.

Solution
Added extra horizontal padding (`padding: 40px 35px`) to the navbar links to give menu items enough space and prevent overflow or misalignment

Scope
This change affects only the CSS file:
- `style.css` — the `.nav li a` selector was updated with adjusted padding.

Tested
- Verified in Chrome (English) and Firefox (Spanish).
- Menu aligns correctly.
- No layout break in either language or browser.

Notes
- This fix is specific to UI layout and does not affect backend or functionality.

Evidence
Chrome (English)
![image](https://github.com/user-attachments/assets/d2523e70-762d-4c15-9245-63d7a43eff66)
Firefox (Spanish)
![image](https://github.com/user-attachments/assets/64d1c332-8632-4913-ada4-88bb08b510e6)
