### PR TITLE
Add FeLV vaccine (English/Spanish) logic for cats and related unit tests

### DIFF
--- a/src/main/java/com/josdem/vetlog/strategy/vaccination/impl/CatVaccinationStrategy.java
+++ b/src/main/java/com/josdem/vetlog/strategy/vaccination/impl/CatVaccinationStrategy.java
@@ -19,6 +19,7 @@ public class CatVaccinationStrategy implements VaccinationStrategy {
     private static final String FVRCP = "FVRCP";
     private static final String DEWORMING = "Deworming";
     private static final String RABIES = "Rabies";
+    private static final String FELV = "FeLV";
 
     private final VaccinationRepository vaccinationRepository;
 
@@ -43,6 +44,7 @@ public class CatVaccinationStrategy implements VaccinationStrategy {
                 registerVaccination(FVRCP, pet);
                 registerVaccination(DEWORMING, pet);
                 registerVaccination(RABIES, pet);
+                registerVaccination(FELV, pet);
             }
         }
     }

--- a/src/main/java/com/josdem/vetlog/util/VaccineFormatter.java
+++ b/src/main/java/com/josdem/vetlog/util/VaccineFormatter.java
@@ -30,7 +30,8 @@ public class VaccineFormatter {
             case "DA2PP" -> "Quintuple Canina";
             case "Deworming" -> "Desparasitación";
             case "Rabies" -> "Rabia";
-            case "FVRCP" -> "Tripe Felina";
+            case "FVRCP" -> "Triple Felina";
+            case "FeLV" -> "Leucemia Felina";
             default -> name;
         };
     }

--- a/src/test/java/com/josdem/vetlog/strategy/CatVaccinationStrategyTest.kt
+++ b/src/test/java/com/josdem/vetlog/strategy/CatVaccinationStrategyTest.kt
@@ -66,4 +66,20 @@ class CatVaccinationStrategyTest {
 
         verify(vaccinationRepository, never()).save(any())
     }
+
+    @Test
+    fun `should apply FeLV vaccine for adult cats`() {
+        log.info("Running test: should apply FeLV vaccine for adult cats")
+        pet.birthDate = LocalDateTime.now().minusWeeks(20)
+
+        catVaccinationStrategy.vaccinate(pet)
+
+        verify(vaccinationRepository).save(
+            argThat { vaccination ->
+                vaccination.name == "FeLV" &&
+                    vaccination.status == VaccinationStatus.PENDING &&
+                    vaccination.pet == pet
+            },
+        )
+    }
 }

--- a/src/test/java/com/josdem/vetlog/util/VaccineFormatterTest.kt
+++ b/src/test/java/com/josdem/vetlog/util/VaccineFormatterTest.kt
@@ -90,6 +90,14 @@ class VaccineFormatterTest {
     }
 
     @Test
+    fun `should format FeLV if locale is Spanish`(testInfo: TestInfo) {
+        log.info(testInfo.displayName)
+        whenever(locale.language).thenReturn("es")
+
+        assertEquals("Leucemia Felina", vaccineFormatter.format("FeLV", locale))
+    }
+
+    @Test
     fun `should format pending status if locale is Spanish`(testInfo: TestInfo) {
         log.info(testInfo.displayName)
         whenever(locale.language).thenReturn("es")


### PR DESCRIPTION
### What was done
- Added FeLV vaccine for cats over 16 weeks old in `CatVaccinationStrategy`.
- Updated `VaccineFormatter` to support localized display of "FeLV" as "Leucemia Felina" (Spanish).
- Added a unit test to ensure the vaccine is applied correctly.
- Confirmed correct display in the app UI and successful test run.

### Screenshots
Chrome (English)
![image](https://github.com/user-attachments/assets/301e6ab7-421a-48b3-90e3-f495b1d37345)

Firefox (Spanish)
![image](https://github.com/user-attachments/assets/87b7062f-0563-4d72-985f-da2a3d978978)
