### PR TITLE
Fix missing status when registering a second pet

### DIFF
--- a/src/main/java/com/josdem/vetlog/controller/PetController.java
+++ b/src/main/java/com/josdem/vetlog/controller/PetController.java
@@ -137,6 +137,7 @@ public class PetController {
         petService.save(petCommand, user);
         modelAndView.addObject(MESSAGE, localeService.getMessage("pet.created", request));
         petCommand = new PetCommand();
+        petCommand.setStatus(PetStatus.OWNED);
         modelAndView.addObject(PET_COMMAND, petCommand);
         return fillModelAndView(modelAndView);
     }

--- a/src/main/java/com/josdem/vetlog/controller/PetController.java
+++ b/src/main/java/com/josdem/vetlog/controller/PetController.java
@@ -35,7 +35,6 @@ import jakarta.validation.Valid;
 
 import java.io.IOException;
 import java.util.Comparator;
-import java.util.stream.Collectors;
 
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;

--- a/src/main/java/com/josdem/vetlog/controller/PetController.java
+++ b/src/main/java/com/josdem/vetlog/controller/PetController.java
@@ -32,9 +32,11 @@ import com.josdem.vetlog.service.VaccinationService;
 import com.josdem.vetlog.validator.PetValidator;
 import jakarta.servlet.http.HttpServletRequest;
 import jakarta.validation.Valid;
+
 import java.io.IOException;
 import java.util.Comparator;
 import java.util.stream.Collectors;
+
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.beans.factory.annotation.Value;
@@ -148,9 +150,7 @@ public class PetController {
                 breedService.getBreedsByType(PetType.DOG).stream()
                         .sorted(Comparator.comparing(
                                 Breed::getName)) // for sorting the initial dog listings alphabetically
-                        .collect(
-                                Collectors
-                                        .toList())); // this overlaps with the breed controller, will there be a way to
+                        .toList()); // this overlaps with the breed controller, will there be a way to
         // unify this?
         modelAndView.addObject("breedsByTypeUrl", breedsByTypeUrl);
         return modelAndView;


### PR DESCRIPTION
## PR: Fix missing `status` when registering a second pet

### Summary

Closes #643

This PR fixes a bug where registering a second pet (without refreshing the page) failed due to the `status` field being `null`.

---

### Root Cause

After submitting the first pet registration, the form/model was reset, but the `status` field was not re-initialized. As a result, the second submission sent a `null` value for `status`, violating the database constraint (`NOT NULL`).

---

### Fix

Explicitly set the `status` to `PetStatus.OWNED` during pet binding:

```java
petCommand.setStatus(PetStatus.OWNED);
```

This ensures that every pet registration includes a valid `status` value, even after the form is reset.

---

### Testing

- Verified that multiple pets can now be registered in sequence without refreshing the page
- Confirmed that `status` is correctly set and stored in the database