### PR TITLE
fix: correct navbar brand height to align logo 

### DIFF
--- a/src/main/resources/static/assets/servizi-dog-theme/css/style.css
+++ b/src/main/resources/static/assets/servizi-dog-theme/css/style.css
@@ -262,6 +262,10 @@ section.section-darker img {
 	box-shadow: 0px 0px 5px #555;
 }
 
+.navbar-brand {
+	height: 100% !important;
+}
+
 .navbar-brand img {
 	width: 250px;
 }


### PR DESCRIPTION
This PR fixes the logo alignment issue in the navbar by overriding the .navbar-brand height to 100% with !important.

I chose to only adjust this height because it directly resolves the problem where the logo lacked proper vertical centering and margin at the bottom. Adding a margin-bottom to the image itself didn’t work due to the parent container’s height constraints and the box model behavior. The root cause was that the parent element of the logo image did not have an appropriate height, preventing correct vertical centering and causing the logo to stick to the element below.

Adding margin-bottom elsewhere could cause layout issues in the future, so this minimal change ensures consistent alignment without side effects.

It still follows the purpose of the fix, to improve the header's look and feel by having a visible separation at the bottom of the header:

![vetlog navbar](https://github.com/user-attachments/assets/8b16b31f-64e6-4f05-a03f-7b311640bf54)
