### PR TITLE
Add logic to create Rabies vaccination record with NEW status after applying

### DIFF
--- a/src/main/java/com/josdem/vetlog/binder/PetBinder.java
+++ b/src/main/java/com/josdem/vetlog/binder/PetBinder.java
@@ -22,10 +22,12 @@ import com.josdem.vetlog.enums.VaccinationStatus;
 import com.josdem.vetlog.exception.BusinessException;
 import com.josdem.vetlog.model.Breed;
 import com.josdem.vetlog.model.Pet;
+import com.josdem.vetlog.model.Vaccination;
 import com.josdem.vetlog.repository.BreedRepository;
 import com.josdem.vetlog.repository.VaccinationRepository;
 import com.josdem.vetlog.util.UuidGenerator;
 import java.time.LocalDate;
+import java.util.List;
 import java.util.Optional;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Component;
@@ -54,11 +56,43 @@ public class PetBinder {
         pet.setSterilized(petCommand.getSterilized());
         pet.setImages(petCommand.getImages());
         pet.setStatus(petCommand.getStatus());
+
+        // Load previous vaccines from the database using the original Pet object (if updating)
+        List<Vaccination> previousVaccines = List.of();
+        if (petCommand.getId() != null) {
+            Pet existingPet = new Pet();
+            existingPet.setId(petCommand.getId());
+            previousVaccines = vaccinationRepository.findAllByPet(existingPet);
+        }
+
+        // Check if Rabies vaccine was changed from PENDING to APPLIED
+        for (Vaccination newVaccine : petCommand.getVaccines()) {
+            if ("Rabies".equalsIgnoreCase(newVaccine.getName())
+                    && newVaccine.getStatus() == VaccinationStatus.APPLIED) {
+                previousVaccines.stream()
+                        .filter(v -> "Rabies".equalsIgnoreCase(v.getName()))
+                        .findFirst()
+                        .ifPresent(oldVaccine -> {
+                            System.out.println("DEBUG: Previous Rabies status was: " + oldVaccine.getStatus());
+                            if (oldVaccine.getStatus() == VaccinationStatus.PENDING) {
+                                // Create a new Rabies vaccine for one year later
+                                Vaccination futureRabies = new Vaccination(
+                                        null, "Rabies", LocalDate.now().plusYears(1), VaccinationStatus.NEW, pet);
+                                vaccinationRepository.save(futureRabies);
+                                System.out.println(
+                                        "DEBUG: Future Rabies vaccine created for date: " + futureRabies.getDate());
+                            }
+                        });
+            }
+        }
+
+        /// Save updated vaccines
         pet.setVaccines(petCommand.getVaccines());
         petCommand.getVaccines().forEach(vaccine -> {
             vaccine.setDate(LocalDate.now());
             vaccinationRepository.save(vaccine);
         });
+
         Optional<Breed> breed = breedRepository.findById(petCommand.getBreed());
         if (breed.isEmpty()) {
             throw new BusinessException("Breed was not found for pet: " + pet.getName());

--- a/src/main/java/com/josdem/vetlog/binder/PetBinder.java
+++ b/src/main/java/com/josdem/vetlog/binder/PetBinder.java
@@ -39,6 +39,8 @@ public class PetBinder {
     private final BreedRepository breedRepository;
     private final VaccinationRepository vaccinationRepository;
 
+    private static final String RABIES_VACCINE = "Rabies";
+
     public Pet bindPet(Command command) {
         PetCommand petCommand = (PetCommand) command;
         Pet pet = new Pet();
@@ -67,20 +69,17 @@ public class PetBinder {
 
         // Check if Rabies vaccine was changed from PENDING to APPLIED
         for (Vaccination newVaccine : petCommand.getVaccines()) {
-            if ("Rabies".equalsIgnoreCase(newVaccine.getName())
+            if (RABIES_VACCINE.equalsIgnoreCase(newVaccine.getName())
                     && newVaccine.getStatus() == VaccinationStatus.APPLIED) {
                 previousVaccines.stream()
-                        .filter(v -> "Rabies".equalsIgnoreCase(v.getName()))
+                        .filter(v -> RABIES_VACCINE.equalsIgnoreCase(v.getName()))
                         .findFirst()
                         .ifPresent(oldVaccine -> {
-                            System.out.println("DEBUG: Previous Rabies status was: " + oldVaccine.getStatus());
                             if (oldVaccine.getStatus() == VaccinationStatus.PENDING) {
                                 // Create a new Rabies vaccine for one year later
                                 Vaccination futureRabies = new Vaccination(
-                                        null, "Rabies", LocalDate.now().plusYears(1), VaccinationStatus.NEW, pet);
+                                        null, RABIES_VACCINE, LocalDate.now().plusYears(1), VaccinationStatus.NEW, pet);
                                 vaccinationRepository.save(futureRabies);
-                                System.out.println(
-                                        "DEBUG: Future Rabies vaccine created for date: " + futureRabies.getDate());
                             }
                         });
             }

--- a/src/main/java/com/josdem/vetlog/enums/VaccinationStatus.java
+++ b/src/main/java/com/josdem/vetlog/enums/VaccinationStatus.java
@@ -18,7 +18,8 @@ package com.josdem.vetlog.enums;
 
 public enum VaccinationStatus {
     PENDING("Pending"),
-    APPLIED("Applied");
+    APPLIED("Applied"),
+    NEW("New");
 
     private final String value;
 

--- a/src/main/resources/db/migration/V1.16__add_new_status_to_vaccination_enum.sql
+++ b/src/main/resources/db/migration/V1.16__add_new_status_to_vaccination_enum.sql
@@ -1,0 +1,1 @@
+ALTER TABLE vaccination MODIFY status ENUM('APPLIED', 'PENDING', 'NEW') NOT NULL;

--- a/src/main/resources/templates/pet/edit.html
+++ b/src/main/resources/templates/pet/edit.html
@@ -88,6 +88,7 @@
                                     <td>
                                         <select th:field="*{vaccines[__${itemStat.index}__].status}" style="height: 50px;">
                                             <option th:each="status : ${T(com.josdem.vetlog.enums.VaccinationStatus).values()}"
+                                                    th:if="${status.name() != 'NEW'}"
                                                     th:value="${status}" th:text="${status.value}"
                                                     th:selected="(${status} == *{vaccines[__${itemStat.index}__].status})"/>
                                         </select>

--- a/src/main/resources/templates/pet/edit.html
+++ b/src/main/resources/templates/pet/edit.html
@@ -87,10 +87,13 @@
                                     <td><input type="text" th:field="*{vaccines[__${itemStat.index}__].name}" readonly style="height: 50px;"/></td>
                                     <td>
                                         <select th:field="*{vaccines[__${itemStat.index}__].status}" style="height: 50px;">
-                                            <option th:each="status : ${T(com.josdem.vetlog.enums.VaccinationStatus).values()}"
-                                                    th:if="${status.name() != 'NEW'}"
-                                                    th:value="${status}" th:text="${status.value}"
-                                                    th:selected="(${status} == *{vaccines[__${itemStat.index}__].status})"/>
+
+                                            <th:block th:each="status : ${T(com.josdem.vetlog.enums.VaccinationStatus).values()}">
+                                                <option th:if="${status.name() != 'NEW'}"
+                                                        th:value="${status}" th:text="${status.value}"
+                                                        th:selected="(${status} == *{vaccines[__${itemStat.index}__].status})">
+                                                </option>
+                                            </th:block>
                                         </select>
                                     </td>
                                 </tr>

--- a/src/test/java/com/josdem/vetlog/binder/PetBinderTest.kt
+++ b/src/test/java/com/josdem/vetlog/binder/PetBinderTest.kt
@@ -36,6 +36,7 @@ import org.junit.jupiter.api.Test
 import org.junit.jupiter.api.TestInfo
 import org.mockito.Mock
 import org.mockito.MockitoAnnotations
+import org.mockito.kotlin.any
 import org.mockito.kotlin.whenever
 import org.slf4j.LoggerFactory
 import java.time.LocalDate
@@ -163,4 +164,42 @@ internal class PetBinderTest {
                     type = PetType.DOG
                 }
         }
+
+    @Test
+    fun `should create a new rabies vaccination with NEW status one year later when updated to APPLIED`(testInfo: TestInfo) {
+        log.info(testInfo.displayName)
+
+        val previousRabies = Vaccination(99L, "Rabies", LocalDate.now(), VaccinationStatus.PENDING, null)
+
+        val appliedRabies = Vaccination(null, "Rabies", LocalDate.now(), VaccinationStatus.APPLIED, null)
+
+        val petCommand =
+            PetCommand().apply {
+                id = 1L
+                name = "Luna"
+                status = PetStatus.OWNED
+                sterilized = false
+                images = listOf(PetImage())
+                breed = 1L
+                vaccines = mutableListOf(appliedRabies)
+                birthDate = "2021-01-01"
+            }
+
+        setBreedExpectations()
+
+        whenever(vaccinationRepository.findAllByPet(any())).thenReturn(listOf(previousRabies))
+
+        val savedVaccinations = mutableListOf<Vaccination>()
+        whenever(vaccinationRepository.save(any())).thenAnswer {
+            val saved = it.arguments[0] as Vaccination
+            savedVaccinations.add(saved)
+            saved
+        }
+
+        val result = petBinder.bindPet(petCommand)
+
+        val futureRabies = savedVaccinations.find { it.name == "Rabies" && it.status == VaccinationStatus.NEW }
+        assertNotNull(futureRabies)
+        assertEquals(LocalDate.now().plusYears(1), futureRabies.date)
+    }
 }


### PR DESCRIPTION
## What was done

When a Rabies vaccine is changed from `PENDING` to `APPLIED`, a new vaccine record is created with:

- **Status:** `NEW`  
- **Date:** 1 year from now

Only `PENDING` and `APPLIED` statuses are shown in the dropdown.

---

## Tests

- Added a unit test to verify that a `NEW` vaccination record is created when Rabies is marked as `APPLIED`.
- All tests are passing.

---

## Notes

To support the new `NEW` status, the enum in the database had to be updated manually.

---

**Please note: the following SQL command must be executed in the production database before deploying this PR:**

```sql
ALTER TABLE vaccination MODIFY status ENUM('APPLIED', 'PENDING', 'NEW') NOT NULL;
```


---

## Screenshots

- Database showing the `NEW` status created automatically after changing from `PENDING` to `APPLIED`:
<img width="1154" height="876" alt="image" src="https://github.com/user-attachments/assets/199c3fbe-0d1b-4ccb-8aac-a0113d6b1583" />
