### PR TITLE
fix: multipart form not working

### DIFF
--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -1,3 +1,6 @@
+server:
+  tomcat:
+    max-part-count: 50
 spring:
   datasource:
     url:  jdbc:mysql://localhost:3306/vetlog


### PR DESCRIPTION
Update server.tomcat.max-part-count to 50 that is the new default value introduced in [tomcat 10.1.43](https://tomcat.apache.org/tomcat-10.1-doc/changelog.html). This value is also present in [new versions of Spring Boot](https://github.com/spring-projects/spring-boot/commit/3ad232dea0a1a81ff59dd7a0eb0c33db58c1a884)

Closes #677 