### PR TITLE
feat: add functionality to prevent log created date change on pet log…

### DIFF
--- a/src/main/java/com/josdem/vetlog/model/PetLog.java
+++ b/src/main/java/com/josdem/vetlog/model/PetLog.java
@@ -25,6 +25,7 @@ import jakarta.persistence.GeneratedValue;
 import jakarta.persistence.Id;
 import jakarta.persistence.JoinColumn;
 import jakarta.persistence.ManyToOne;
+import jakarta.persistence.PrePersist;
 import java.time.LocalDateTime;
 import lombok.Getter;
 import lombok.Setter;
@@ -54,8 +55,8 @@ public class PetLog {
 
     private boolean hasAttachment = false;
 
-    @Column(nullable = false)
-    private LocalDateTime dateCreated = LocalDateTime.now();
+    @Column(nullable = false, updatable = false)
+    private LocalDateTime dateCreated;
 
     @ManyToOne(fetch = FetchType.LAZY)
     @JoinColumn(name = "pet_id")
@@ -63,4 +64,9 @@ public class PetLog {
 
     @Column(name = "username", nullable = false)
     private String username;
+
+    @PrePersist
+    protected void onCreate() {
+        dateCreated = LocalDateTime.now();
+    }
 }


### PR DESCRIPTION
#666 Updated PetLog entity dateCreated field to be set only once on insertion.

<img width="1215" height="470" alt="Screenshot from 2025-08-24 01-03-57" src="https://github.com/user-attachments/assets/db26f88c-e83e-4c68-9187-09faf0827880" />
<img width="1215" height="470" alt="Screenshot from 2025-08-24 01-04-24" src="https://github.com/user-attachments/assets/11ef59b5-129a-49f1-9251-a3cf56870ab4" />

