### PR TITLE
feat: update dog vaccines with Puppy and C4CV

### DIFF
--- a/src/main/java/com/josdem/vetlog/strategy/vaccination/impl/DogVaccinationStrategy.java
+++ b/src/main/java/com/josdem/vetlog/strategy/vaccination/impl/DogVaccinationStrategy.java
@@ -19,6 +19,8 @@ public class DogVaccinationStrategy implements VaccinationStrategy {
     private static final String C6CV = "C6CV";
     private static final String DEWORMING = "Deworming";
     private static final String RABIES = "Rabies";
+    private static final String PUPPY = "Puppy";
+    private static final String C4CV = "C4CV";
 
     private final VaccinationRepository vaccinationRepository;
 
@@ -30,12 +32,12 @@ public class DogVaccinationStrategy implements VaccinationStrategy {
             case 0, 1, 2, 3, 4, 5 -> log.info("No vaccination needed");
             case 6, 7, 8 -> {
                 log.info("First vaccination");
-                registerVaccination(C6CV, pet);
+                registerVaccination(PUPPY, pet);
                 registerVaccination(DEWORMING, pet);
             }
             case 9, 10, 11, 12 -> {
                 log.info("Second vaccination");
-                registerVaccination(C6CV, pet);
+                registerVaccination(C4CV, pet);
                 registerVaccination(DEWORMING, pet);
             }
             default -> {

--- a/src/main/java/com/josdem/vetlog/util/VaccineFormatter.java
+++ b/src/main/java/com/josdem/vetlog/util/VaccineFormatter.java
@@ -27,6 +27,7 @@ public class VaccineFormatter {
             return name;
         }
         return switch (name) {
+            case "C4CV" -> "Quintuple Canina";
             case "C6CV" -> "Sextuple Canina";
             case "Deworming" -> "Desparasitación";
             case "Rabies" -> "Rabia";

--- a/src/test/java/com/josdem/vetlog/util/VaccineFormatterTest.kt
+++ b/src/test/java/com/josdem/vetlog/util/VaccineFormatterTest.kt
@@ -42,6 +42,31 @@ class VaccineFormatterTest {
     }
 
     @Test
+    fun `should not format Puppy irrespective of language`(testInfo: TestInfo) {
+        log.info(testInfo.displayName)
+        whenever(locale.language).thenReturn("es")
+        assertEquals("Puppy", vaccineFormatter.format("Puppy", locale))
+        whenever(locale.language).thenReturn("en")
+        assertEquals("Puppy", vaccineFormatter.format("Puppy", locale))
+    }
+
+    @Test
+    fun `should format C4CV if locale is Spanish`(testInfo: TestInfo) {
+        log.info(testInfo.displayName)
+        whenever(locale.language).thenReturn("es")
+
+        assertEquals("Quintuple Canina", vaccineFormatter.format("C4CV", locale))
+    }
+
+    @Test
+    fun `should not format C4CV if locale is English`(testInfo: TestInfo) {
+        log.info(testInfo.displayName)
+        whenever(locale.language).thenReturn("en")
+
+        assertEquals("C4CV", vaccineFormatter.format("C4CV", locale))
+    }
+
+    @Test
     fun `should format C6CV if locale is Spanish`(testInfo: TestInfo) {
         log.info(testInfo.displayName)
         whenever(locale.language).thenReturn("es")


### PR DESCRIPTION
#701 and #702 resolution PR - replaced C6CV with Puppy for 1st vaccination and with C4CV for 2nd vaccination for dogs. Added test cases to test the updated vaccines format.