### PR TITLE
Add chip ID number to pet register form - frontend

### DIFF
--- a/src/main/java/com/josdem/vetlog/binder/PetBinder.java
+++ b/src/main/java/com/josdem/vetlog/binder/PetBinder.java
@@ -56,6 +56,7 @@ public class PetBinder {
             pet.setBirthDate(LocalDate.parse(petCommand.getBirthDate()));
         }
         pet.setSterilized(petCommand.getSterilized());
+        pet.setChip_id(petCommand.getChip_id());
         pet.setImages(petCommand.getImages());
         pet.setStatus(petCommand.getStatus());
 
@@ -83,6 +84,7 @@ public class PetBinder {
         command.setName(pet.getName());
         command.setBirthDate(pet.getBirthDate().toString());
         command.setSterilized(pet.getSterilized());
+        command.setChip_id(pet.getChip_id());
         command.setStatus(pet.getStatus());
         command.setImages(pet.getImages());
         command.setBreed(pet.getBreed().getId());

--- a/src/main/java/com/josdem/vetlog/command/PetCommand.java
+++ b/src/main/java/com/josdem/vetlog/command/PetCommand.java
@@ -45,6 +45,8 @@ public class PetCommand implements Command {
 
     private Boolean sterilized = false;
 
+    private String chip_id = "800000000000001";
+
     @Min(1L)
     private Long breed;
 

--- a/src/main/java/com/josdem/vetlog/model/Pet.java
+++ b/src/main/java/com/josdem/vetlog/model/Pet.java
@@ -60,6 +60,9 @@ public class Pet {
     @Column(nullable = false)
     private Boolean sterilized = false;
 
+    @Column(columnDefinition = "CHAR(15)")
+    private String chip_id;
+
     @Column(nullable = false)
     private LocalDateTime dateCreated = LocalDateTime.now();
 

--- a/src/main/resources/i18n/messages.properties
+++ b/src/main/resources/i18n/messages.properties
@@ -81,6 +81,7 @@ pet.name=Pet's Name
 pet.birthDate=Date of Birth
 pet.sterilized=Sterilized
 pet.not.sterilized=Not Sterilized
+pet.chip.id=Chip ID
 pet.vaccines=Vaccines
 pet.breed=Breed
 pet.type=Pet Type

--- a/src/main/resources/i18n/messages_es.properties
+++ b/src/main/resources/i18n/messages_es.properties
@@ -81,6 +81,7 @@ pet.name=Nombre de la mascota
 pet.birthDate=Fecha de Nacimiento
 pet.sterilized=Esterilizado
 pet.not.sterilized=Sin Esterilizar
+pet.chip.id=Chip ID
 pet.vaccines=Vacunas
 pet.breed=Raza
 pet.type=Tipo de Mascota

--- a/src/main/resources/templates/pet/create.html
+++ b/src/main/resources/templates/pet/create.html
@@ -43,6 +43,10 @@
                                    placeholder="sterilized" id='sterilized'/>
                             <label th:if="${#fields.hasErrors('sterilized')}" th:errors="*{sterilized}"></label>
                             <br/>
+                            <label for="chip-id"><h4 th:text="#{pet.chip.id}"/></label>
+                            <input type="text" name='chip-id' th:field="*{chip_id}" class="form-control"
+                                   id='chip-id' minlength="15" maxlength="15" th:value="*{chip_id}">
+                            <label th:if="${#fields.hasErrors('chip_id')}" th:errors="*{chip_id}"></label>
                             <br/>
                             <label for="type"><h4 th:text="#{pet.type}"/></label>
                             <select id="typeSelector" name="type" th:field="*{type}" class="form-control"

--- a/src/main/resources/templates/pet/edit.html
+++ b/src/main/resources/templates/pet/edit.html
@@ -1,4 +1,5 @@
 <!DOCTYPE html>
+<!--suppress ALL -->
 <html xmlns="http://www.w3.org/1999/xhtml" xmlns:th="http://www.thymeleaf.org"
       xmlns:sec="http://www.thymeleaf.org/extras/spring-security" th:lang="${#locale.language}">
 <head>
@@ -71,6 +72,11 @@
                             <input type="checkbox" name='sterilized' th:data-testid="petSterilized" th:field="*{sterilized}" class="form-control"
                                    placeholder="sterilized" id='sterilized'/>
                             <label th:if="${#fields.hasErrors('sterilized')}" th:errors="*{sterilized}"></label>
+                            <br/>
+                            <label for="chip-id"><h4 th:text="#{pet.chip.id}"/></label>
+                            <input type="text" name='chip-id' th:field="*{chip_id}" class="form-control"
+                                   id='chip-id' minlength="15" maxlength="15" th:value="*{chip_id}">
+                            <label th:if="${#fields.hasErrors('chip_id')}" th:errors="*{chip_id}"></label>
                             <br/>
                             <table th:if="${!petCommand.vaccines.isEmpty()}">
                                 <thead>

--- a/src/main/resources/templates/pet/list.html
+++ b/src/main/resources/templates/pet/list.html
@@ -80,6 +80,7 @@
                                     <li th:data-testid="petBirhdate" th:text="${@dateFormatter.formatToDate(pet.birthDate, #locale)}"/>
                                     <li th:data-testid="petBreed" th:text="${pet.breed.name}"/>
                                     <li th:data-testid="petSterilized" th:text="${pet.sterilized}? #{pet.sterilized} : #{pet.not.sterilized}"/>
+                                    <li th:data-testid="petChip" th:if="${pet.chip_id} neq '800000000000001'" th:text="*{pet.chip_id}"/>
                                 </ul>
                                 <br>
                                 <table th:if="${!pet.vaccines.isEmpty()}">

--- a/src/test/java/com/josdem/vetlog/controller/PetControllerTest.kt
+++ b/src/test/java/com/josdem/vetlog/controller/PetControllerTest.kt
@@ -234,6 +234,7 @@ class PetControllerTest {
                 .param("uuid", PET_UUID)
                 .param("birthDate", "2024-08-22")
                 .param("sterilized", "true")
+                .param("chip_id", "123456789012345")
                 .param("breed", "11")
                 .param("user", "1")
                 .param("status", status.toString())


### PR DESCRIPTION
Added the chip ID input to pet register form in reference to Issue #716 and 
Took the liberty to put also on the edit form and the number on the pets list, for consistency.