### PR TITLE
Add/dog deworming

### DIFF
--- a/src/main/java/com/josdem/vetlog/strategy/vaccination/impl/DogVaccinationStrategy.java
+++ b/src/main/java/com/josdem/vetlog/strategy/vaccination/impl/DogVaccinationStrategy.java
@@ -29,7 +29,10 @@ public class DogVaccinationStrategy implements VaccinationStrategy {
         long weeks = ChronoUnit.WEEKS.between(pet.getBirthDate(), LocalDate.now());
 
         switch ((int) weeks) {
-            case 0, 1, 2, 3, 4, 5 -> log.info("No vaccination needed");
+            case 0, 1, 2, 3, 4, 5 -> {
+                log.info("Early deworming");
+                registerVaccination(DEWORMING, pet);
+            }
             case 6, 7, 8 -> {
                 log.info("First vaccination");
                 registerVaccination(PUPPY, pet);

--- a/src/test/java/com/josdem/vetlog/strategy/DogVaccinationStrategyTest.kt
+++ b/src/test/java/com/josdem/vetlog/strategy/DogVaccinationStrategyTest.kt
@@ -36,7 +36,7 @@ class DogVaccinationStrategyTest {
     }
 
     @ParameterizedTest
-    @CsvSource("6, 2", "8, 2", "9, 2", "12, 2", "20, 3")
+    @CsvSource("1, 1, "6, 2", "8, 2", "9, 2", "12, 2", "20, 3")
     fun `should  save  vaccines  based  on  pet  age`(
         weeks: Int,
         times: Int,
@@ -54,15 +54,5 @@ class DogVaccinationStrategyTest {
                         vaccination.pet == pet
                 },
             )
-    }
-
-    @Test
-    fun `should not save vaccination when pet is not old enough`(testInfo: TestInfo) {
-        log.info("Running test: {}", testInfo.displayName)
-        pet.birthDate = LocalDate.now().minusWeeks(1)
-
-        dogVaccinationStrategy.vaccinate(pet)
-
-        verify(vaccinationRepository, never()).save(any())
     }
 }

--- a/src/test/java/com/josdem/vetlog/strategy/DogVaccinationStrategyTest.kt
+++ b/src/test/java/com/josdem/vetlog/strategy/DogVaccinationStrategyTest.kt
@@ -5,17 +5,13 @@ import com.josdem.vetlog.model.Pet
 import com.josdem.vetlog.repository.VaccinationRepository
 import com.josdem.vetlog.strategy.vaccination.impl.DogVaccinationStrategy
 import org.junit.jupiter.api.BeforeEach
-import org.junit.jupiter.api.Test
-import org.junit.jupiter.api.TestInfo
 import org.junit.jupiter.params.ParameterizedTest
 import org.junit.jupiter.params.provider.CsvSource
 import org.mockito.Mock
 import org.mockito.Mockito.argThat
-import org.mockito.Mockito.never
 import org.mockito.Mockito.times
 import org.mockito.Mockito.verify
 import org.mockito.MockitoAnnotations
-import org.mockito.kotlin.any
 import org.slf4j.LoggerFactory
 import java.time.LocalDate
 

--- a/src/test/java/com/josdem/vetlog/strategy/DogVaccinationStrategyTest.kt
+++ b/src/test/java/com/josdem/vetlog/strategy/DogVaccinationStrategyTest.kt
@@ -36,7 +36,7 @@ class DogVaccinationStrategyTest {
     }
 
     @ParameterizedTest
-    @CsvSource("1, 1, "6, 2", "8, 2", "9, 2", "12, 2", "20, 3")
+    @CsvSource("1, 1", "6, 2", "8, 2", "9, 2", "12, 2", "20, 3")
     fun `should  save  vaccines  based  on  pet  age`(
         weeks: Int,
         times: Int,


### PR DESCRIPTION
## Description
Adds deworming registration for puppies aged 0-5 weeks to improve vaccination records.

## Changes Made
- Modified `DogVaccinationStrategy` to register deworming for puppies in weeks 0-5
- Updated `DogVaccinationStrategyTest` to include test case for young puppy deworming
- All relevant unit tests passing

## Acceptance Criteria Met
- Deworming registration visible in case 0-5 weeks
- Test cases modified accordingly
- All tests passing (DogVaccinationStrategyTest suite)
