### PR TITLE
Center thumbnail container in adopt.html

### DIFF
--- a/src/main/resources/templates/telephone/adopt.html
+++ b/src/main/resources/templates/telephone/adopt.html
@@ -12,7 +12,7 @@
 <br/><br/>
 <div class="container">
     <div class="row">
-        <div class="col-sm-6 col-md-4">
+        <div class="col-sm-6 col-md-4 col-sm-offset-3 col-md-offset-4">
             <div class="thumbnail">
                 <div th:data-testid="errorMessage" th:if="${errorMessage}" class="alert alert-warning" th:text="${errorMessage}"/>
                 <div th:if="${!pet.images.isEmpty()}">


### PR DESCRIPTION
This PR fixes issue #747.

## Summary
- Thumbnail container is now centered by adding some offset to the grid (`col-sm-offset-3` and `col-md-offset-4`). This change is based on how other parts of the UI are centered.

Before:
<img width="1178" height="617" alt="Screenshot 2025-10-23 at 9 55 37" src="https://github.com/user-attachments/assets/a6d14662-a852-4136-bc3f-9e921980f02b" />

After:
<img width="1168" height="621" alt="Screenshot 2025-10-23 at 9 57 55" src="https://github.com/user-attachments/assets/67258f21-8fe3-4067-8317-fe93eb8e148b" />

**Let me know if any changes are needed. This is my first contribution to an open-source project. 😃**
