### PR TITLE
Issue #752: update project dependencies to latest versions

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -3,30 +3,30 @@ buildscript {
     gradlePluginPortal()
   }
   dependencies {
-    classpath("org.springframework.boot:spring-boot-gradle-plugin:3.5.5")
-    classpath("org.flywaydb:flyway-mysql:11.13.2")
+    classpath("org.springframework.boot:spring-boot-gradle-plugin:3.5.7")
+    classpath("org.flywaydb:flyway-mysql:11.15.0")
   }
 }
 
 plugins {
-  id("org.springframework.boot") version "3.5.6"
+  id("org.springframework.boot") version "3.5.7"
   id("io.spring.dependency-management") version "1.1.7"
-  id("org.flywaydb.flyway") version "11.13.2"
+  id("org.flywaydb.flyway") version "11.15.0"
   id("org.sonarqube") version "6.3.1.5724"
   id("jacoco")
   id("java")
   id("com.diffplug.spotless") version "8.0.0"
-  id("org.jetbrains.kotlin.jvm") version "2.2.20"
+  id("org.jetbrains.kotlin.jvm") version "2.2.21"
 }
 
-val gcpVersion by extra("7.3.1")
+val gcpVersion by extra("7.4.0")
 val retrofitVersion by extra("3.0.0")
 val mockitoCoreVersion by extra("5.20.0")
 val annotationsVersion by extra("26.0.2")
 val jsonSmartVersion by extra("2.6.0")
 val jaxbVersion by extra("2.3.1")
 val cglibVersion by extra("3.3.0")
-val mockitoKotlinVersion by extra("6.0.0")
+val mockitoKotlinVersion by extra("6.1.0")
 
 group = "com.josdem.vetlog"
 version = "3.2.1"
@@ -98,7 +98,7 @@ dependencies {
   // Database and ORM
   runtimeOnly("com.mysql:mysql-connector-j")
   implementation("org.flywaydb:flyway-core")
-  runtimeOnly("org.flywaydb:flyway-mysql")
+  runtimeOnly("org.flywaydb:flyway-mysql:11.15.0")
 
   // Compile-time dependencies
   compileOnly("org.projectlombok:lombok")


### PR DESCRIPTION
Fixes #752 

 - Spring Boot upgraded to 3.5.7
 - Flyway Gradle plugin and Flyway MySQL updated to 11.15.0
 - Kotlin JVM updated to 2.2.21
 - Spring Cloud GCP dependencies updated to 7.4.0
 - Mockito Kotlin updated to 6.1.0
 - All tests verified passing