### PR TITLE
fix: ensure fallback image is available in the view model -> Issue #760

### DIFF
--- a/src/main/java/com/josdem/vetlog/controller/AdoptionController.java
+++ b/src/main/java/com/josdem/vetlog/controller/AdoptionController.java
@@ -50,6 +50,9 @@ public class AdoptionController {
     @Value("${imageBucket}")
     private String imageBucket;
 
+    @Value("${defaultImage}")
+    private String defaultImage;
+
     @InitBinder("adoptionCommand")
     private void initBinder(WebDataBinder binder) {
         binder.addValidators(adoptionValidator);
@@ -74,6 +77,7 @@ public class AdoptionController {
         var modelAndView = new ModelAndView("pet/listForAdoption");
         modelAndView.addObject("pets", pets);
         modelAndView.addObject("gcpImageUrl", gcpUrl + imageBucket + "/");
+        modelAndView.addObject("defaultImage", defaultImage);
         return modelAndView;
     }
 

--- a/src/main/resources/templates/pet/listForAdoption.html
+++ b/src/main/resources/templates/pet/listForAdoption.html
@@ -60,6 +60,9 @@
                             </a>
                         </div>
                     </div>
+                    <div th:if="${pet.images.isEmpty()}" align="center">
+                        <img style="width:320px;height:300px;" th:attr="src=@{${gcpImageUrl} + ${defaultImage}}"/>
+                    </div>
                     <div th:data-testid="adoptionContainer" class="caption">
                         <h3 th:data-testid="petName" th:text="${pet.name}"></h3>
                         <p th:data-testid="petBirhdate" th:text="${@dateFormatter.formatToDate(pet.birthDate, #locale)}"/>


### PR DESCRIPTION
## Fix for issue #760 

**Issue**: Adoption save container does not contain default image

### What
- Add defaultImage to the ModelAndView in save endpoint.
- Wire defaultImage so carousel fallback works in the listForAdoption.html template

### Why
- Enables the Thymeleaf fallback when pet.images is empty, preventing empty/broken thumbnails.

### Impact
- View-only change; no storage or controller logic altered.

# 
## Behavior
**Before**:  Pets with images display correctly; pets without images render no thumbnail.
**After**:  Pets with images still display correctly (no changes); pets without images render the configured default image. Added component that reads the defaultImage. Just like other templates that does render the default Image.
+ Ensure the pets list renders a fallback image when a pet has no uploaded images by:    
   - Passing defaultImage into the view model.
   - Using that value in the Thymeleaf template fallback block below the carousel definition (shown when pet.images is empty).
