### PR TITLE
fix: update Dockerfile gradle version to support Spring boot 4

### DIFF
--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -7,7 +7,7 @@ COPY src/main/resources/static/assets/servizi-dog-theme/package*.json ./
 RUN npm install
 
 # --- Build Stage ---
-FROM gradle:8.8-jdk21 AS build
+FROM gradle:8.14-jdk21 AS build
 WORKDIR /app
 
 # Copy only gradle files and project metadata first for better caching


### PR DESCRIPTION
The current Dockerfile uses Gradle 8.8, which causes a build failure when paired with Spring Boot 4.0.6 (which requires Gradle 8.14 or later). This PR updates the Gradle base image to version 8.14 to resolve the build exception.