### PR TITLE
Preserve pet dateCreated on update

### DIFF
--- a/src/main/java/com/josdem/vetlog/service/impl/PetServiceImpl.java
+++ b/src/main/java/com/josdem/vetlog/service/impl/PetServiceImpl.java
@@ -66,8 +66,9 @@ public class PetServiceImpl implements PetService {
     @Transactional
     public Pet update(Command command) throws IOException {
         var petCommand = (PetCommand) command;
-        recoveryImages(petCommand);
+        var persistedPet = recoveryImages(petCommand);
         var pet = petBinder.bindPet(petCommand);
+        pet.setDateCreated(persistedPet.getDateCreated());
         var user = getUser(petCommand.getUser());
         user.ifPresentOrElse(pet::setUser, () -> {
             throw new BusinessException(NO_USER_WAS_FOUND_WITH_ID + petCommand.getUser());
@@ -123,11 +124,12 @@ public class PetServiceImpl implements PetService {
         petRepository.delete(pet);
     }
 
-    private void recoveryImages(PetCommand command) {
-        var pet = petRepository.findById(command.getId());
-        pet.ifPresentOrElse(value -> command.setImages(value.getImages()), () -> {
-            throw new BusinessException(NO_PET_WAS_FOUND_WITH_ID + command.getId());
-        });
+    private Pet recoveryImages(PetCommand command) {
+        var pet = petRepository
+                .findById(command.getId())
+                .orElseThrow(() -> new BusinessException(NO_PET_WAS_FOUND_WITH_ID + command.getId()));
+        command.setImages(pet.getImages());
+        return pet;
     }
 
     private Optional<User> getUser(Long id) {

--- a/src/test/java/com/josdem/vetlog/service/PetServiceTest.kt
+++ b/src/test/java/com/josdem/vetlog/service/PetServiceTest.kt
@@ -43,6 +43,7 @@ import org.mockito.kotlin.verify
 import org.mockito.kotlin.whenever
 import org.slf4j.LoggerFactory
 import java.io.IOException
+import java.time.LocalDateTime
 import java.util.Optional
 
 internal class PetServiceTest {
@@ -117,20 +118,27 @@ internal class PetServiceTest {
     @Throws(IOException::class)
     fun `Updating a pet`(testInfo: TestInfo) {
         log.info(testInfo.displayName)
-        pet!!.images = mutableListOf()
+        val originalDateCreated = LocalDateTime.now().minusDays(10)
+        val persistedPet =
+            Pet().apply {
+                images = mutableListOf()
+                dateCreated = originalDateCreated
+            }
+        val updatedPet = Pet()
         val command: PetCommand = mock()
 
         whenever(command.id).thenReturn(2L)
-        whenever(petRepository.findById(2L)).thenReturn(Optional.of(pet!!))
-        whenever(petBinder.bindPet(command)).thenReturn(pet)
+        whenever(petRepository.findById(2L)).thenReturn(Optional.of(persistedPet))
+        whenever(petBinder.bindPet(command)).thenReturn(updatedPet)
         whenever(command.user).thenReturn(1L)
         whenever(command.adopter).thenReturn(3L)
         whenever(userRepository.findById(1L)).thenReturn(Optional.of(user!!))
         whenever(userRepository.findById(3L)).thenReturn(Optional.of(adopter!!))
 
         service.update(command)
-        assertEquals(user, pet!!.user)
-        assertEquals(adopter, pet!!.adopter)
+        assertEquals(user, updatedPet.user)
+        assertEquals(adopter, updatedPet.adopter)
+        assertEquals(originalDateCreated, updatedPet.dateCreated)
         verify(petImageService).attachFile(command)
         verify(petRepository).save(any())
         verify(command).images = any()


### PR DESCRIPTION
Fixes #854

Keeps the persisted \dateCreated\ value when updating a pet, while still recovering existing images before binding the submitted command.

Validation:
- \git diff --check\

I tried \./gradlew.bat test --tests com.josdem.vetlog.service.PetServiceTest --no-daemon --console=plain\, but the build requires Java 21 and this machine only has Java 17 installed.