### PR TITLE
#842 Create Rabies vaccination with status NEW when TRICAT is applied and pet is older than 16 weeks

### DIFF
--- a/src/main/java/com/josdem/vetlog/helper/VaccinationHelper.java
+++ b/src/main/java/com/josdem/vetlog/helper/VaccinationHelper.java
@@ -54,7 +54,7 @@ public class VaccinationHelper {
             TRICAT_VACCINE, java.time.Period.ofDays(45));
 
     private static final Map<String, java.time.Period> NEXT_RABIES_VACCINE_OFFSET = Map.of(
-            TRICAT_VACCINE, java.time.Period.ofDays(45), // added TRICAT with time period
+            TRICAT_VACCINE, java.time.Period.ofDays(45),
             C6CV_VACCINE, java.time.Period.ofDays(15),
             TRICAT_BOOST_VACCINE, java.time.Period.ofDays(45),
             RABIES_VACCINE, java.time.Period.ofYears(1));
@@ -68,12 +68,8 @@ public class VaccinationHelper {
                     && newVaccine.getStatus() == VaccinationStatus.APPLIED
                     && previousVaccines.stream()
                             .anyMatch(previousVaccine -> appliedName.equalsIgnoreCase(previousVaccine.getName())
-                                    && previousVaccine.getStatus() == VaccinationStatus.PENDING)) {
-
-                // for TRICAT petOldreThan16Weeks
-                if (TRICAT_VACCINE.equalsIgnoreCase(appliedName) && !isPetOlderThan16Weeks(pet)) {
-                    continue;
-                }
+                                    && previousVaccine.getStatus() == VaccinationStatus.PENDING)
+                    && isSpecificCriteriaSatisfiedForApplyingNextVaccine(appliedName, RABIES_VACCINE, pet)) {
                 saveNewVaccine(RABIES_VACCINE, LocalDate.now().plus(NEXT_RABIES_VACCINE_OFFSET.get(appliedName)), pet);
             }
         }
@@ -105,16 +101,14 @@ public class VaccinationHelper {
                     .map(weeks -> weeks >= 9 && weeks <= 16)
                     .orElse(false);
         }
+        if (TRICAT_VACCINE.equalsIgnoreCase(appliedName) && RABIES_VACCINE.equalsIgnoreCase(nextName)) {
+            return Optional.ofNullable(pet)
+                    .map(Pet::getBirthDate)
+                    .map(dob -> ChronoUnit.DAYS.between(dob, LocalDate.now()))
+                    .map(days -> days > (16 * 7))
+                    .orElse(false);
+        }
         return true;
-    }
-
-    // added helper method to check pet age
-    private boolean isPetOlderThan16Weeks(Pet pet) {
-        return Optional.ofNullable(pet)
-                .map(Pet::getBirthDate)
-                .map(dob -> ChronoUnit.WEEKS.between(dob, LocalDate.now()))
-                .map(weeks -> weeks > 16)
-                .orElse(false);
     }
 
     private void saveNewVaccine(String name, LocalDate date, Pet pet) {

--- a/src/main/java/com/josdem/vetlog/helper/VaccinationHelper.java
+++ b/src/main/java/com/josdem/vetlog/helper/VaccinationHelper.java
@@ -54,6 +54,7 @@ public class VaccinationHelper {
             TRICAT_VACCINE, java.time.Period.ofDays(45));
 
     private static final Map<String, java.time.Period> NEXT_RABIES_VACCINE_OFFSET = Map.of(
+            TRICAT_VACCINE, java.time.Period.ofDays(45), // added TRICAT with time period
             C6CV_VACCINE, java.time.Period.ofDays(15),
             TRICAT_BOOST_VACCINE, java.time.Period.ofDays(45),
             RABIES_VACCINE, java.time.Period.ofYears(1));
@@ -68,6 +69,11 @@ public class VaccinationHelper {
                     && previousVaccines.stream()
                             .anyMatch(previousVaccine -> appliedName.equalsIgnoreCase(previousVaccine.getName())
                                     && previousVaccine.getStatus() == VaccinationStatus.PENDING)) {
+
+                // for TRICAT petOldreThan16Weeks
+                if (TRICAT_VACCINE.equalsIgnoreCase(appliedName) && !isPetOlderThan16Weeks(pet)) {
+                    continue;
+                }
                 saveNewVaccine(RABIES_VACCINE, LocalDate.now().plus(NEXT_RABIES_VACCINE_OFFSET.get(appliedName)), pet);
             }
         }
@@ -100,6 +106,15 @@ public class VaccinationHelper {
                     .orElse(false);
         }
         return true;
+    }
+
+    // added helper method to check pet age
+    private boolean isPetOlderThan16Weeks(Pet pet) {
+        return Optional.ofNullable(pet)
+                .map(Pet::getBirthDate)
+                .map(dob -> ChronoUnit.WEEKS.between(dob, LocalDate.now()))
+                .map(weeks -> weeks > 16)
+                .orElse(false);
     }
 
     private void saveNewVaccine(String name, LocalDate date, Pet pet) {

--- a/src/test/java/com/josdem/vetlog/helper/VaccinationHelperTest.kt
+++ b/src/test/java/com/josdem/vetlog/helper/VaccinationHelperTest.kt
@@ -28,6 +28,7 @@ import org.mockito.Mock
 import org.mockito.MockitoAnnotations
 import org.mockito.kotlin.any
 import org.mockito.kotlin.argThat
+import org.mockito.kotlin.never
 import org.mockito.kotlin.times
 import org.mockito.kotlin.verify
 import org.mockito.kotlin.whenever
@@ -227,7 +228,6 @@ class VaccinationHelperTest {
         verify(vaccinationRepository, times(0)).save(any())
     }
 
-    // positive test case for pet older 16 weeks -> rabies created
     @Test
     fun `should create Rabies 45 days later when TRICAT applied and pet is older than 16 weeks`(testInfo: TestInfo) {
         log.info(testInfo.displayName)
@@ -250,7 +250,6 @@ class VaccinationHelperTest {
         )
     }
 
-    // negative case pet younger -> rabies not created
     @Test
     fun `should not create Rabies when TRICAT applied and pet is 16 weeks or younger`(testInfo: TestInfo) {
         log.info(testInfo.displayName)
@@ -263,5 +262,33 @@ class VaccinationHelperTest {
         vaccinationHelper.validateRabiesVaccine(listOf(previousVaccines), listOf(newVaccines), pet)
 
         verify(vaccinationRepository, times(0)).save(any())
+    }
+
+    @Test
+    fun `should not create Rabies when pet is exactly 16 weeks old`(testInfo: TestInfo) {
+        log.info(testInfo.displayName)
+        val pet = Pet()
+        pet.birthDate = LocalDate.now().minusWeeks(16)
+        val previousVaccines = Vaccination(1L, "TRICAT", LocalDate.now(), VaccinationStatus.PENDING, pet)
+        val newVaccines = Vaccination(1L, "TRICAT", LocalDate.now(), VaccinationStatus.APPLIED, pet)
+        whenever(vaccinationRepository.findAllByPetId(1L)).thenReturn(listOf(previousVaccines))
+
+        vaccinationHelper.validateRabiesVaccine(listOf(previousVaccines), listOf(newVaccines), pet)
+
+        verify(vaccinationRepository, never()).save(any())
+    }
+
+    @Test
+    fun `should create Rabies when pet is older than 16 weeks by one day`(testInfo: TestInfo) {
+        log.info(testInfo.displayName)
+        val today = LocalDate.now()
+        val pet = Pet()
+        pet.birthDate = today.minusWeeks(16).minusDays(1)
+        val previousVaccines = Vaccination(1L, "TRICAT", today, VaccinationStatus.PENDING, pet)
+        val newVaccines = Vaccination(1L, "TRICAT", today, VaccinationStatus.APPLIED, pet)
+        whenever(vaccinationRepository.findAllByPetId(1L)).thenReturn(listOf(previousVaccines))
+        vaccinationHelper.validateRabiesVaccine(listOf(previousVaccines), listOf(newVaccines), pet)
+
+        verify(vaccinationRepository).save(any())
     }
 }

--- a/src/test/java/com/josdem/vetlog/helper/VaccinationHelperTest.kt
+++ b/src/test/java/com/josdem/vetlog/helper/VaccinationHelperTest.kt
@@ -226,4 +226,42 @@ class VaccinationHelperTest {
 
         verify(vaccinationRepository, times(0)).save(any())
     }
+
+    // positive test case for pet older 16 weeks -> rabies created
+    @Test
+    fun `should create Rabies 45 days later when TRICAT applied and pet is older than 16 weeks`(testInfo: TestInfo) {
+        log.info(testInfo.displayName)
+        val pet = Pet()
+        pet.birthDate = LocalDate.now().minusWeeks(20)
+        val previousVaccines = Vaccination(1L, "TRICAT", LocalDate.now(), VaccinationStatus.PENDING, pet)
+        val newVaccines = Vaccination(1L, "TRICAT", LocalDate.now(), VaccinationStatus.APPLIED, pet)
+        whenever(vaccinationRepository.findAllByPetId(1L)).thenReturn(listOf(previousVaccines))
+
+        vaccinationHelper.validateRabiesVaccine(listOf(previousVaccines), listOf(newVaccines), pet)
+
+        val expectedDate = LocalDate.now().plusDays(45)
+        verify(vaccinationRepository).save(
+            argThat { vaccination ->
+                vaccination.name == "Rabies" &&
+                    vaccination.status == VaccinationStatus.NEW &&
+                    vaccination.date == expectedDate &&
+                    vaccination.pet == pet
+            },
+        )
+    }
+
+    // negative case pet younger -> rabies not created
+    @Test
+    fun `should not create Rabies when TRICAT applied and pet is 16 weeks or younger`(testInfo: TestInfo) {
+        log.info(testInfo.displayName)
+        val pet = Pet()
+        pet.birthDate = LocalDate.now().minusWeeks(12)
+        val previousVaccines = Vaccination(1L, "TRICAT", LocalDate.now(), VaccinationStatus.PENDING, pet)
+        val newVaccines = Vaccination(1L, "TRICAT", LocalDate.now(), VaccinationStatus.APPLIED, pet)
+        whenever(vaccinationRepository.findAllByPetId(1L)).thenReturn(listOf(previousVaccines))
+
+        vaccinationHelper.validateRabiesVaccine(listOf(previousVaccines), listOf(newVaccines), pet)
+
+        verify(vaccinationRepository, times(0)).save(any())
+    }
 }


### PR DESCRIPTION
Closes #842

## Changes
- Added `TRICAT` to `NEXT_RABIES_VACCINE_OFFSET` map in `VaccinationHelper.java`
- Added `isPetOlderThan16Weeks()` private method to guard RABIES creation
- Added guard in `validateRabiesVaccine()` to skip RABIES if pet is 16 weeks or younger
- Added 2 new test cases in `VaccinationHelperTest.kt`

## Test Cases Added
- should create Rabies 45 days later when TRICAT applied and pet is older than 16 weeks
- should not create Rabies when TRICAT applied and pet is 16 weeks or younger