### PR TITLE
Fix #862: Correct corrupted Spanish localization strings

### DIFF
--- a/src/main/resources/i18n/messages_es.properties
+++ b/src/main/resources/i18n/messages_es.properties
@@ -134,8 +134,8 @@ adoption.mobile=Proporciona tu teléfono
 adoption.thanks=Hola, gracias por adoptar
 adoption.wishes=Estamos felices que has encontrado un nuevo miembro de la familia, esperamos que disfruten de esta nueva etapa juntos.
 adoption.email.sent=Un correo electrónico fue enviado al propietario de la mascota en adopción, por favor espera por noticias.
-adoption.address=Direcci�n
-adoption.address.placeholder=Calle, n�mero, interior, colonia, estado, pa�s.
+adoption.address=Dirección
+adoption.address.placeholder=Calle, número, interior, colonia, estado, país.
 
 vet.view.search.title=Buscar por usuario
 vet.list=Buscar


### PR DESCRIPTION
<img width="1206" height="678" alt="image" src="https://github.com/user-attachments/assets/540079e1-a7ae-47ce-9cc5-2726e7d40e69" />

This PR fixes corrupted Spanish localization strings in `messages_es.properties`.

Closes #862 

## Changes

* Fixed `adoption.address`
* Fixed `adoption.address.placeholder`

## Result

The labels now render correctly in the adoption form UI as shown in the attached screenshot.

