### PR TITLE
fix: do not create FeLV vaccine unless pet is a cat that goes outside often

### DIFF
--- a/src/main/java/com/josdem/vetlog/helper/VaccinationHelper.java
+++ b/src/main/java/com/josdem/vetlog/helper/VaccinationHelper.java
@@ -122,7 +122,7 @@ public class VaccinationHelper {
                 .map(Breed::getType)
                 .filter(PetType.CAT::equals)
                 .isPresent();
-        return isCat && Boolean.TRUE.equals(pet.getGoingOutOften());
+        return isCat && pet.getGoingOutOften();
     }
 
     private void saveNewVaccine(String name, LocalDate date, Pet pet) {

--- a/src/main/java/com/josdem/vetlog/helper/VaccinationHelper.java
+++ b/src/main/java/com/josdem/vetlog/helper/VaccinationHelper.java
@@ -68,7 +68,7 @@ public class VaccinationHelper {
                                     && previousVaccine.getStatus() == VaccinationStatus.PENDING)
                     && isSpecificCriteriaSatisfiedForApplyingNextVaccine(appliedName, RABIES_VACCINE, pet)) {
                 saveNewVaccine(RABIES_VACCINE, LocalDate.now().plus(NEXT_RABIES_VACCINE_OFFSET.get(appliedName)), pet);
-                if (RABIES_VACCINE.equalsIgnoreCase(appliedName)) {
+                if (RABIES_VACCINE.equalsIgnoreCase(appliedName) && isFelvVaccineApplicable(pet)) {
                     saveNewVaccine(
                             FELV_VACCINE, LocalDate.now().plus(NEXT_RABIES_VACCINE_OFFSET.get(FELV_VACCINE)), pet);
                 }
@@ -112,6 +112,17 @@ public class VaccinationHelper {
                     .orElse(false);
         }
         return true;
+    }
+
+    private boolean isFelvVaccineApplicable(Pet pet) {
+        if (pet == null) {
+            return false;
+        }
+        boolean isCat = Optional.ofNullable(pet.getBreed())
+                .map(Breed::getType)
+                .filter(PetType.CAT::equals)
+                .isPresent();
+        return isCat && Boolean.TRUE.equals(pet.getGoingOutOften());
     }
 
     private void saveNewVaccine(String name, LocalDate date, Pet pet) {

--- a/src/test/java/com/josdem/vetlog/helper/VaccinationHelperTest.kt
+++ b/src/test/java/com/josdem/vetlog/helper/VaccinationHelperTest.kt
@@ -337,4 +337,68 @@ class VaccinationHelperTest {
             },
         )
     }
+
+    @Test
+    fun `should create FeLV vaccine when Rabies applied and cat is going out often`(testInfo: TestInfo) {
+        log.info(testInfo.displayName)
+        val pet = Pet()
+        pet.goingOutOften = true
+        pet.breed = Breed().apply { type = PetType.CAT }
+        val previousVaccines = Vaccination(1L, "Rabies", LocalDate.now(), VaccinationStatus.PENDING, pet)
+        val newVaccines = Vaccination(1L, "Rabies", LocalDate.now(), VaccinationStatus.APPLIED, pet)
+        whenever(vaccinationRepository.findAllByPetId(1L)).thenReturn(listOf(previousVaccines))
+
+        vaccinationHelper.validateRabiesVaccine(listOf(previousVaccines), listOf(newVaccines), pet)
+
+        val expectedDate = LocalDate.now().plusDays(21)
+        verify(vaccinationRepository).save(
+            argThat { vaccination ->
+                vaccination.name == "FeLV" &&
+                    vaccination.status == VaccinationStatus.NEW &&
+                    vaccination.date == expectedDate &&
+                    vaccination.pet == pet
+            },
+        )
+    }
+
+    @Test
+    fun `should not create FeLV vaccine when Rabies applied and cat is not going out often`(testInfo: TestInfo) {
+        log.info(testInfo.displayName)
+        val pet = Pet()
+        pet.goingOutOften = false
+        pet.breed = Breed().apply { type = PetType.CAT }
+        val previousVaccines = Vaccination(1L, "Rabies", LocalDate.now(), VaccinationStatus.PENDING, pet)
+        val newVaccines = Vaccination(1L, "Rabies", LocalDate.now(), VaccinationStatus.APPLIED, pet)
+        whenever(vaccinationRepository.findAllByPetId(1L)).thenReturn(listOf(previousVaccines))
+
+        vaccinationHelper.validateRabiesVaccine(listOf(previousVaccines), listOf(newVaccines), pet)
+
+        verify(vaccinationRepository, never()).save(
+            argThat { vaccination -> vaccination.name == "FeLV" },
+        )
+        verify(vaccinationRepository).save(
+            argThat { vaccination ->
+                vaccination.name == "Rabies" &&
+                    vaccination.status == VaccinationStatus.NEW &&
+                    vaccination.pet == pet
+            },
+        )
+    }
+
+    @Test
+    fun `should not create FeLV vaccine when Rabies applied and pet is a dog`(testInfo: TestInfo) {
+        log.info(testInfo.displayName)
+        val pet = Pet()
+        pet.goingOutOften = true
+        pet.breed = Breed().apply { type = PetType.DOG }
+        val previousVaccines = Vaccination(1L, "Rabies", LocalDate.now(), VaccinationStatus.PENDING, pet)
+        val newVaccines = Vaccination(1L, "Rabies", LocalDate.now(), VaccinationStatus.APPLIED, pet)
+        whenever(vaccinationRepository.findAllByPetId(1L)).thenReturn(listOf(previousVaccines))
+
+        vaccinationHelper.validateRabiesVaccine(listOf(previousVaccines), listOf(newVaccines), pet)
+
+        verify(vaccinationRepository, never()).save(
+            argThat { vaccination -> vaccination.name == "FeLV" },
+        )
+    }
 }


### PR DESCRIPTION
## Summary

Fixes #888.

`VaccinationHelper.validateRabiesVaccine` created a FeLV vaccine for **every** pet whenever a Rabies vaccine was applied. FeLV (Feline Leukemia) is feline-specific and only indicated for cats with outdoor exposure, so this generated incorrect FeLV records for cats kept indoors (and for non-cats).

## Change

- Guard FeLV creation behind a new `isFelvVaccineApplicable(pet)` check: the pet's breed type must be `CAT` **and** `goingOutOften` must be `true`.
- Rabies generation itself is unchanged.

## Tests

Added unit tests in `VaccinationHelperTest` covering:
- cat + `goingOutOften = true` → FeLV **is** created
- cat + `goingOutOften = false` → FeLV is **not** created (the scenario in #888)
- dog → FeLV is **not** created

`VaccinationHelperTest` passes (17/17). Since FeLV is feline-specific, this also addresses the dog case described in #887.