### PR TITLE
Change pet_adoption table charset to utf8mb4

### DIFF
--- a/src/main/resources/db/migration/V1.23__update_charset_pet_adoption.sql
+++ b/src/main/resources/db/migration/V1.23__update_charset_pet_adoption.sql
@@ -1,0 +1,6 @@
+-- Flyway migration: change charset of pet_adoption table from latin1 to utf8mb4
+-- This allows storing emoji and full Unicode characters in the description column
+-- References: https://github.com/josdem/vetlog-spring-boot/issues/892
+
+ALTER TABLE pet_adoption
+    CONVERT TO CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci;


### PR DESCRIPTION
Closes #892

## What this does

Adds Flyway migration `V1.23__update_charset_pet_adoption.sql` that changes the `pet_adoption` table character set from `latin1` to `utf8mb4` with `utf8mb4_unicode_ci` collation.

## Why

The `latin1` charset does not support emoji or full Unicode. Changing to `utf8mb4` allows users to store emoji in the `description` column of the `pet_adoption` table.

## How

Uses `ALTER TABLE ... CONVERT TO CHARACTER SET utf8mb4` which changes both the table default charset and all existing text columns in a single statement, consistent with MySQL best practices for charset migrations.